### PR TITLE
Fix SystemUI hook resolution on ColorOS 16.0.10.x while keeping 16.0.9.x compatibility

### DIFF
--- a/app/src/main/java/io/github/andrealtb/lockscreenlyrics/LockscreenLyricsModule.java
+++ b/app/src/main/java/io/github/andrealtb/lockscreenlyrics/LockscreenLyricsModule.java
@@ -90,10 +90,11 @@ public final class LockscreenLyricsModule extends XposedModule {
     private static final String LYRIC_PARSE_TRACE_TAG = "LockscreenLyricsParse";
     private static final String LYRIC_RENDER_PIPELINE_REVISION =
             "official-ownership-r4-geometry-reveal";
-    // Test build: the reporting user can only send LSP logs, so module diagnostics are
-    // enabled by default instead of relying on log.tag.* system properties.
-    private static final boolean LYRIC_DEBUG_DIAGNOSTICS_ENABLED = true;
-    private static final boolean TRANSLATION_BUTTON_DIAGNOSTICS_ENABLED = true;
+    // Debug builds keep module diagnostics enabled by default (reporting users only send LSP
+    // logs), while release builds stay at the production defaults; no log.tag.* properties
+    // are required either way.
+    private static final boolean LYRIC_DEBUG_DIAGNOSTICS_ENABLED = BuildConfig.DEBUG;
+    private static final boolean TRANSLATION_BUTTON_DIAGNOSTICS_ENABLED = BuildConfig.DEBUG;
     private static final boolean LYRIC_VERBOSE_DIAGNOSTICS_ENABLED = false;
     private static final boolean LYRIC_PARSE_TRACE_ENABLED = false;
     private static final int LYRIC_PARSE_TRACE_CHUNK_SIZE = 3000;

--- a/app/src/main/java/io/github/andrealtb/lockscreenlyrics/LockscreenLyricsModule.java
+++ b/app/src/main/java/io/github/andrealtb/lockscreenlyrics/LockscreenLyricsModule.java
@@ -90,8 +90,10 @@ public final class LockscreenLyricsModule extends XposedModule {
     private static final String LYRIC_PARSE_TRACE_TAG = "LockscreenLyricsParse";
     private static final String LYRIC_RENDER_PIPELINE_REVISION =
             "official-ownership-r4-geometry-reveal";
-    private static final boolean LYRIC_DEBUG_DIAGNOSTICS_ENABLED = false;
-    private static final boolean TRANSLATION_BUTTON_DIAGNOSTICS_ENABLED = false;
+    // Test build: the reporting user can only send LSP logs, so module diagnostics are
+    // enabled by default instead of relying on log.tag.* system properties.
+    private static final boolean LYRIC_DEBUG_DIAGNOSTICS_ENABLED = true;
+    private static final boolean TRANSLATION_BUTTON_DIAGNOSTICS_ENABLED = true;
     private static final boolean LYRIC_VERBOSE_DIAGNOSTICS_ENABLED = false;
     private static final boolean LYRIC_PARSE_TRACE_ENABLED = false;
     private static final int LYRIC_PARSE_TRACE_CHUNK_SIZE = 3000;
@@ -1029,7 +1031,8 @@ public final class LockscreenLyricsModule extends XposedModule {
             try {
                 cached = SystemUiDexKitAdapter.resolve(classLoader);
                 systemUiDexKitTargets = cached;
-                info("Resolved SystemUI private hooks via DexKit");
+                info("Resolved SystemUI private hooks via DexKit (rusVariant=" + cached.rusVariant
+                        + ", whitelistGetter=" + whitelistGetterLabel(cached) + ")");
                 return cached;
             } catch (Throwable dexKitFailure) {
                 error("Failed to resolve SystemUI private hooks via DexKit; trying legacy names",
@@ -1038,13 +1041,25 @@ public final class LockscreenLyricsModule extends XposedModule {
             try {
                 cached = SystemUiDexKitAdapter.resolveLegacy(classLoader);
                 systemUiDexKitTargets = cached;
-                info("Resolved SystemUI private hooks via legacy-name fallback");
+                info("Resolved SystemUI private hooks via legacy-name fallback (rusVariant="
+                        + cached.rusVariant + ", whitelistGetter=" + whitelistGetterLabel(cached)
+                        + ")");
                 return cached;
             } catch (Throwable fallbackFailure) {
                 error("Failed to resolve SystemUI private hook targets", fallbackFailure);
                 return null;
             }
         }
+    }
+
+    private static String whitelistGetterLabel(SystemUiDexKitAdapter.Targets targets) {
+        if (targets.getRusWhiteList != null) {
+            return "getRusWhiteList";
+        }
+        if (targets.mediaRusConfigWhiteListGetter != null) {
+            return "MediaRusConfig.getWhiteList";
+        }
+        return "none";
     }
 
     private static boolean isSupportedProcess(String processName) {
@@ -1291,11 +1306,28 @@ public final class LockscreenLyricsModule extends XposedModule {
             }
             try {
                 Method getRusWhiteList = targets.getRusWhiteList;
-                getRusWhiteList.setAccessible(true);
-                hook(getRusWhiteList)
-                        .setId(HOOK_ID_RUS_GET_WHITE_LIST)
-                        .setExceptionMode(XposedInterface.ExceptionMode.PROTECTIVE)
-                        .intercept(this::onOplusMediaRusGetWhiteList);
+                if (getRusWhiteList != null) {
+                    getRusWhiteList.setAccessible(true);
+                    hook(getRusWhiteList)
+                            .setId(HOOK_ID_RUS_GET_WHITE_LIST)
+                            .setExceptionMode(XposedInterface.ExceptionMode.PROTECTIVE)
+                            .intercept(this::onOplusMediaRusGetWhiteList);
+                } else {
+                    Method mediaRusConfigWhiteListGetter = targets.mediaRusConfigWhiteListGetter;
+                    if (mediaRusConfigWhiteListGetter != null) {
+                        mediaRusConfigWhiteListGetter.setAccessible(true);
+                        hook(mediaRusConfigWhiteListGetter)
+                                .setId(HOOK_ID_RUS_GET_WHITE_LIST)
+                                .setExceptionMode(XposedInterface.ExceptionMode.PROTECTIVE)
+                                .intercept(this::onOplusMediaRusGetWhiteList);
+                    } else {
+                        warn(
+                                LyricLogFormatter.Area.SYSTEM_UI,
+                                "bypass",
+                                "Skipped OPlus media whitelist bypass: no whitelist getter "
+                                        + "available on this build");
+                    }
+                }
 
                 Method getLyricEntrance = targets.getLyricEntrance;
                 getLyricEntrance.setAccessible(true);
@@ -15387,7 +15419,9 @@ public final class LockscreenLyricsModule extends XposedModule {
             return;
         }
         LyricLogFormatter.Area area = LyricLogFormatter.classifyArea(message);
-        Log.i(TAG, formatLog(area, LyricLogFormatter.classifyEvent(message), message));
+        String formatted = formatLog(area, LyricLogFormatter.classifyEvent(message), message);
+        Log.i(TAG, formatted);
+        log(Log.INFO, TAG, formatted);
     }
 
     private void settingsInfo(String event, String message) {

--- a/app/src/main/java/io/github/andrealtb/lockscreenlyrics/SystemUiDexKitAdapter.java
+++ b/app/src/main/java/io/github/andrealtb/lockscreenlyrics/SystemUiDexKitAdapter.java
@@ -100,21 +100,11 @@ final class SystemUiDexKitAdapter {
             Method getLyricEntrance = requireUniqueMethod(
                     selectorClass,
                     "lyric entrance lookup",
-                    method -> !Modifier.isStatic(method.getModifiers())
-                            && method.getReturnType() == int.class
-                            && hasParameterTypes(method, String.class));
+                    SystemUiDexKitAdapter::isLyricEntranceLookupShape);
             Method updatePkgActionsRule = requireUniqueMethod(
                     selectorClass,
                     "media action rule update",
-                    method -> !Modifier.isStatic(method.getModifiers())
-                            && method.getReturnType() == void.class
-                            && hasParameterTypes(
-                            method,
-                            Map.class,
-                            Map.class,
-                            Map.class,
-                            Map.class,
-                            Map.class));
+                    SystemUiDexKitAdapter::isUpdatePkgActionsRuleShape);
             Method createActionsFromState = requireUniqueMethod(
                     strategyClass,
                     "media action builder",
@@ -456,6 +446,18 @@ final class SystemUiDexKitAdapter {
                 Map.class,
                 Map.class,
                 Map.class);
+    }
+
+    /**
+     * ColorOS 16.0.10.x added a sibling {@code getLyricEnable(String):int} lookup with the
+     * same shape as the lyric-entrance lookup, so the exact name is required here; the class
+     * itself is still resolved by DexKit anchors.
+     */
+    static boolean isLyricEntranceLookupShape(Method method) {
+        return !Modifier.isStatic(method.getModifiers())
+                && method.getReturnType() == int.class
+                && hasParameterTypes(method, String.class)
+                && "getLyricEntrance".equals(method.getName());
     }
 
     static boolean isWhiteListGetterShape(Method method) {

--- a/app/src/main/java/io/github/andrealtb/lockscreenlyrics/SystemUiDexKitAdapter.java
+++ b/app/src/main/java/io/github/andrealtb/lockscreenlyrics/SystemUiDexKitAdapter.java
@@ -360,7 +360,10 @@ final class SystemUiDexKitAdapter {
     /**
      * ColorOS 16.0.10.x moved the persisted media RUS whitelist into a dedicated config value
      * object; the old {@code OplusMediaRusUpdateManager.getRusWhiteList()} was removed. The
-     * getter keeps the same shape, so the same predicate applies.
+     * config class is a Kotlin data class, so shape matching is ambiguous (its synthetic
+     * {@code component2()}/{@code component3()} and {@code getBlackList()} all return
+     * zero-arg {@code List}); the class itself is resolved by un-obfuscated name, so the
+     * getter is resolved by exact name as well.
      */
     private static Method findMediaRusConfigWhiteListGetter(ClassLoader classLoader)
             throws ReflectiveOperationException {
@@ -371,10 +374,13 @@ final class SystemUiDexKitAdapter {
         } catch (ClassNotFoundException e) {
             return null;
         }
-        return findOptionalMethod(
-                mediaRusConfigClass,
-                "media RUS config whitelist getter",
-                SystemUiDexKitAdapter::isWhiteListGetterShape);
+        try {
+            Method getWhiteList = mediaRusConfigClass.getDeclaredMethod("getWhiteList");
+            getWhiteList.setAccessible(true);
+            return getWhiteList;
+        } catch (NoSuchMethodException e) {
+            return null;
+        }
     }
 
     static boolean isDealEndTagShape(Method method) {

--- a/app/src/main/java/io/github/andrealtb/lockscreenlyrics/SystemUiDexKitAdapter.java
+++ b/app/src/main/java/io/github/andrealtb/lockscreenlyrics/SystemUiDexKitAdapter.java
@@ -95,7 +95,7 @@ final class SystemUiDexKitAdapter {
             Method getRusWhiteList = findOptionalMethod(
                     rusManagerClass,
                     "RUS whitelist getter",
-                    SystemUiDexKitAdapter::isWhiteListGetterShape);
+                    SystemUiDexKitAdapter::isRusWhiteListGetterShape);
             Method mediaRusConfigWhiteListGetter = findMediaRusConfigWhiteListGetter(classLoader);
             Method getLyricEntrance = requireUniqueMethod(
                     selectorClass,
@@ -460,8 +460,14 @@ final class SystemUiDexKitAdapter {
                 && "getLyricEntrance".equals(method.getName());
     }
 
-    static boolean isWhiteListGetterShape(Method method) {
-        return !Modifier.isStatic(method.getModifiers())
+    /**
+     * Legacy {@code OplusMediaRusUpdateManager.getRusWhiteList()} on ColorOS 16.0.9.x style
+     * builds. The exact name is required so a future sibling zero-arg {@code List} getter
+     * cannot make optional resolution ambiguous (which would abort all SystemUI hooks).
+     */
+    static boolean isRusWhiteListGetterShape(Method method) {
+        return "getRusWhiteList".equals(method.getName())
+                && !Modifier.isStatic(method.getModifiers())
                 && method.getParameterCount() == 0
                 && List.class.isAssignableFrom(method.getReturnType());
     }

--- a/app/src/main/java/io/github/andrealtb/lockscreenlyrics/SystemUiDexKitAdapter.java
+++ b/app/src/main/java/io/github/andrealtb/lockscreenlyrics/SystemUiDexKitAdapter.java
@@ -41,79 +41,62 @@ final class SystemUiDexKitAdapter {
                     classLoader,
                     "OPlus media RUS manager",
                     "com.oplus.systemui.media",
-                    "parseSaveXmlValue whiteList: ",
-                    "getRusWhiteList: cache is empty",
-                    "app_systemui_oplus_media_controller_config.xml");
+                    new String[]{
+                            "parseSaveXmlValue whiteList: ",
+                            "getRusWhiteList: cache is empty",
+                            "app_systemui_oplus_media_controller_config.xml"},
+                    new String[]{
+                            "parseSaveXmlValue whiteList: ",
+                            "parseSaveXmlValue pkgRuleMap: ",
+                            "applyConfig version="});
             Class<?> selectorClass = findSingleClass(
                     bridge,
                     classLoader,
                     "OPlus media action selector",
                     "com.oplus.systemui.media",
-                    "not rule, use Actions",
-                    "oplusActionConfig=",
-                    "Test MediaAction, but not rule, use notification Actions");
+                    new String[]{
+                            "not rule, use Actions",
+                            "oplusActionConfig=",
+                            "Test MediaAction, but not rule, use notification Actions"});
             Class<?> strategyClass = findSingleClass(
                     bridge,
                     classLoader,
                     "OPlus media action strategy",
                     "com.oplus.systemui.media",
-                    "createActionsFromState. oplusActionConfigList = ");
+                    new String[]{"createActionsFromState. oplusActionConfigList = "});
             Class<?> lyricLoaderClass = findSingleClass(
                     bridge,
                     classLoader,
                     "OPlus lyric loader",
                     "com.oplus.systemui.media",
-                    "loadLyricInBg reason: lyric is avilable, lyric= ",
-                    "loadLyricInBg reason: song changed, lyric= ",
-                    "Failed to parse lyric data: ");
+                    new String[]{
+                            "loadLyricInBg reason: lyric is avilable, lyric= ",
+                            "loadLyricInBg reason: song changed, lyric= ",
+                            "Failed to parse lyric data: "});
             Class<?> seedlingBundleClass = findSingleClass(
                     bridge,
                     classLoader,
                     "Seedling media bundle mapper",
                     "com.oplus.systemui.seedlingservice",
-                    "mediaId",
-                    "currentLyric",
-                    "lastPositionUpdateTime",
-                    "shouldShowLyric");
+                    new String[]{
+                            "mediaId",
+                            "currentLyric",
+                            "lastPositionUpdateTime",
+                            "shouldShowLyric"});
 
             Method dealEndTag = requireUniqueMethod(
                     rusManagerClass,
                     "RUS end-tag handler",
-                    method -> Modifier.isStatic(method.getModifiers())
-                            && method.getReturnType() == void.class
-                            && hasParameterTypes(
-                            method,
-                            String.class,
-                            Set.class,
-                            Set.class,
-                            List.class,
-                            List.class,
-                            Map.class,
-                            Map.class,
-                            Map.class,
-                            Map.class,
-                            Map.class));
+                    SystemUiDexKitAdapter::isDealEndTagShape);
             Method saveListToSp = requireUniqueMethod(
                     rusManagerClass,
                     "RUS persistence",
-                    method -> !Modifier.isStatic(method.getModifiers())
-                            && method.getReturnType() == void.class
-                            && hasParameterTypes(
-                            method,
-                            Context.class,
-                            Set.class,
-                            Set.class,
-                            Map.class,
-                            Map.class,
-                            Map.class,
-                            Map.class,
-                            Map.class));
-            Method getRusWhiteList = requireUniqueMethod(
+                    SystemUiDexKitAdapter::isSaveListToSpShape);
+            Method getRusWhiteList = findOptionalMethod(
                     rusManagerClass,
                     "RUS whitelist getter",
-                    method -> !Modifier.isStatic(method.getModifiers())
-                            && method.getParameterCount() == 0
-                            && List.class.isAssignableFrom(method.getReturnType()));
+                    SystemUiDexKitAdapter::isWhiteListGetterShape);
+            Method mediaRusConfigWhiteListGetter = findMediaRusConfigWhiteListGetter(classLoader);
             Method getLyricEntrance = requireUniqueMethod(
                     selectorClass,
                     "lyric entrance lookup",
@@ -165,12 +148,14 @@ final class SystemUiDexKitAdapter {
                     dealEndTag,
                     saveListToSp,
                     getRusWhiteList,
+                    mediaRusConfigWhiteListGetter,
                     getLyricEntrance,
                     updatePkgActionsRule,
                     createActionsFromState,
                     loadLyricInBg,
                     mediaDataToBundle,
-                    true);
+                    true,
+                    getRusWhiteList != null ? RUS_VARIANT_OLD : RUS_VARIANT_NEW);
         }
     }
 
@@ -190,21 +175,22 @@ final class SystemUiDexKitAdapter {
         Class<?> seedlingBundleClass = classLoader.loadClass(
                 "com.oplus.systemui.seedlingservice.utils.SeedlingMediaDataHandleUtils");
 
-        return new Targets(
-                rusManagerClass.getDeclaredMethod(
-                        "dealEndTag",
-                        String.class,
-                        Set.class,
-                        Set.class,
-                        List.class,
-                        List.class,
-                        Map.class,
-                        Map.class,
-                        Map.class,
-                        Map.class,
-                        Map.class),
-                rusManagerClass.getDeclaredMethod(
-                        "saveListToSP",
+        Method dealEndTag = rusManagerClass.getDeclaredMethod(
+                "dealEndTag",
+                String.class,
+                Set.class,
+                Set.class,
+                List.class,
+                List.class,
+                Map.class,
+                Map.class,
+                Map.class,
+                Map.class,
+                Map.class);
+        Method saveListToSp = findDeclaredMethod(
+                rusManagerClass,
+                "saveListToSP",
+                new Class<?>[]{
                         Context.class,
                         Set.class,
                         Set.class,
@@ -212,16 +198,44 @@ final class SystemUiDexKitAdapter {
                         Map.class,
                         Map.class,
                         Map.class,
-                        Map.class),
-                rusManagerClass.getDeclaredMethod("getRusWhiteList"),
+                        Map.class},
+                new Class<?>[]{
+                        Context.class,
+                        Set.class,
+                        Set.class,
+                        Map.class,
+                        Map.class,
+                        Map.class,
+                        Map.class,
+                        Map.class,
+                        Map.class,
+                        int.class});
+        Method getRusWhiteList = findOptionalDeclaredMethod(rusManagerClass, "getRusWhiteList");
+        Method mediaRusConfigWhiteListGetter = findMediaRusConfigWhiteListGetter(classLoader);
+        Method updatePkgActionsRule = findDeclaredMethod(
+                selectorClass,
+                "updatePkgActionsRule",
+                new Class<?>[]{
+                        Map.class,
+                        Map.class,
+                        Map.class,
+                        Map.class,
+                        Map.class},
+                new Class<?>[]{
+                        Map.class,
+                        Map.class,
+                        Map.class,
+                        Map.class,
+                        Map.class,
+                        Map.class});
+
+        return new Targets(
+                dealEndTag,
+                saveListToSp,
+                getRusWhiteList,
+                mediaRusConfigWhiteListGetter,
                 selectorClass.getDeclaredMethod("getLyricEntrance", String.class),
-                selectorClass.getDeclaredMethod(
-                        "updatePkgActionsRule",
-                        Map.class,
-                        Map.class,
-                        Map.class,
-                        Map.class,
-                        Map.class),
+                updatePkgActionsRule,
                 strategyClass.getDeclaredMethod(
                         "createActionsFromState",
                         String.class,
@@ -240,7 +254,33 @@ final class SystemUiDexKitAdapter {
                         List.class,
                         boolean.class,
                         boolean.class),
-                false);
+                false,
+                getRusWhiteList != null ? RUS_VARIANT_OLD : RUS_VARIANT_NEW);
+    }
+
+    private static Method findDeclaredMethod(
+            Class<?> owner,
+            String name,
+            Class<?>[]... parameterSets) throws NoSuchMethodException {
+        NoSuchMethodException lastFailure = null;
+        for (Class<?>[] parameterTypes : parameterSets) {
+            try {
+                return owner.getDeclaredMethod(name, parameterTypes);
+            } catch (NoSuchMethodException e) {
+                lastFailure = e;
+            }
+        }
+        throw lastFailure;
+    }
+
+    private static Method findOptionalDeclaredMethod(Class<?> owner, String name) {
+        for (Method method : owner.getDeclaredMethods()) {
+            if (method.getName().equals(name)) {
+                method.setAccessible(true);
+                return method;
+            }
+        }
+        return null;
     }
 
     private static void ensureDexKitLoaded() {
@@ -261,16 +301,161 @@ final class SystemUiDexKitAdapter {
             ClassLoader classLoader,
             String description,
             String packageName,
-            String... strings) throws ReflectiveOperationException {
+            String[]... anchorSets) throws ReflectiveOperationException {
         ClassDataList classes = bridge.findClass(FindClass.create()
                 .searchPackages(packageName)
-                .matcher(ClassMatcher.create().usingEqStrings(strings)));
+                .matcher(buildAnchorMatcher(anchorSets)));
         if (classes.size() != 1) {
             throw new IllegalStateException(
-                    "Expected one " + description + ", found " + classes.size() + ": " + classes);
+                    "Expected one " + description + ", found " + classes.size() + ": " + classes
+                            + " (anchor sets=" + anchorSets.length + ")");
         }
         ClassData classData = classes.get(0);
         return classData.getInstance(classLoader);
+    }
+
+    /**
+     * Each anchor set is an AND group (every string must be used by the same class); multiple
+     * sets are combined with OR so one query tolerates structurally different builds.
+     */
+    static ClassMatcher buildAnchorMatcher(String[]... anchorSets) {
+        if (anchorSets.length == 0) {
+            throw new IllegalArgumentException("At least one anchor set required");
+        }
+        ClassMatcher matcher = ClassMatcher.create();
+        if (anchorSets.length == 1) {
+            matcher.usingEqStrings(anchorSets[0]);
+        } else {
+            ClassMatcher[] anchorMatchers = new ClassMatcher[anchorSets.length];
+            for (int i = 0; i < anchorSets.length; i++) {
+                anchorMatchers[i] = ClassMatcher.create().usingEqStrings(anchorSets[i]);
+            }
+            matcher.anyOf(anchorMatchers);
+        }
+        return matcher;
+    }
+
+    static Method findOptionalMethod(
+            Class<?> owner,
+            String description,
+            Predicate<Method> predicate) {
+        Method match = null;
+        for (Method method : owner.getDeclaredMethods()) {
+            if (!predicate.test(method)) {
+                continue;
+            }
+            if (match != null) {
+                throw new IllegalStateException(
+                        "Expected one " + description + " in " + owner.getName()
+                                + ", found at least " + match + " and " + method);
+            }
+            match = method;
+        }
+        if (match != null) {
+            match.setAccessible(true);
+        }
+        return match;
+    }
+
+    /**
+     * ColorOS 16.0.10.x moved the persisted media RUS whitelist into a dedicated config value
+     * object; the old {@code OplusMediaRusUpdateManager.getRusWhiteList()} was removed. The
+     * getter keeps the same shape, so the same predicate applies.
+     */
+    private static Method findMediaRusConfigWhiteListGetter(ClassLoader classLoader)
+            throws ReflectiveOperationException {
+        Class<?> mediaRusConfigClass;
+        try {
+            mediaRusConfigClass = classLoader.loadClass(
+                    "com.oplus.systemui.media.seedling.rus.MediaRusConfig");
+        } catch (ClassNotFoundException e) {
+            return null;
+        }
+        return findOptionalMethod(
+                mediaRusConfigClass,
+                "media RUS config whitelist getter",
+                SystemUiDexKitAdapter::isWhiteListGetterShape);
+    }
+
+    static boolean isDealEndTagShape(Method method) {
+        return Modifier.isStatic(method.getModifiers())
+                && method.getReturnType() == void.class
+                && hasParameterTypes(
+                method,
+                String.class,
+                Set.class,
+                Set.class,
+                List.class,
+                List.class,
+                Map.class,
+                Map.class,
+                Map.class,
+                Map.class,
+                Map.class);
+    }
+
+    /**
+     * ColorOS 16.0.9.x: instance method with {@code (Context, Set, Set, Map x5)}.
+     * ColorOS 16.0.10.x: static method with {@code (Context, Set, Set, Map x5, Map, int)}.
+     */
+    static boolean isSaveListToSpShape(Method method) {
+        if (method.getReturnType() != void.class) {
+            return false;
+        }
+        if (!Modifier.isStatic(method.getModifiers())) {
+            return hasParameterTypes(
+                    method,
+                    Context.class,
+                    Set.class,
+                    Set.class,
+                    Map.class,
+                    Map.class,
+                    Map.class,
+                    Map.class,
+                    Map.class);
+        }
+        return hasParameterTypes(
+                method,
+                Context.class,
+                Set.class,
+                Set.class,
+                Map.class,
+                Map.class,
+                Map.class,
+                Map.class,
+                Map.class,
+                Map.class,
+                int.class);
+    }
+
+    /**
+     * ColorOS 16.0.9.x passes five maps; 16.0.10.x adds a sixth (lyric enable) map.
+     */
+    static boolean isUpdatePkgActionsRuleShape(Method method) {
+        if (Modifier.isStatic(method.getModifiers()) || method.getReturnType() != void.class) {
+            return false;
+        }
+        return hasParameterTypes(
+                method,
+                Map.class,
+                Map.class,
+                Map.class,
+                Map.class,
+                Map.class)
+                || hasParameterTypes(
+                method,
+                Map.class,
+                Map.class,
+                Map.class,
+                Map.class,
+                Map.class,
+                Map.class);
+    }
+
+    static boolean isWhiteListGetterShape(Method method) {
+        return !Modifier.isStatic(method.getModifiers())
+                && method.getParameterCount() == 0
+                && List.class.isAssignableFrom(method.getReturnType());
     }
 
     private static Method requireUniqueMethod(
@@ -304,33 +489,44 @@ final class SystemUiDexKitAdapter {
     static final class Targets {
         final Method dealEndTag;
         final Method saveListToSp;
+        /** Present on ColorOS 16.0.9.x style builds; {@code null} on 16.0.10.x style builds. */
         final Method getRusWhiteList;
+        /** Present on ColorOS 16.0.10.x style builds; {@code null} on older builds. */
+        final Method mediaRusConfigWhiteListGetter;
         final Method getLyricEntrance;
         final Method updatePkgActionsRule;
         final Method createActionsFromState;
         final Method loadLyricInBg;
         final Method mediaDataToBundle;
         final boolean resolvedByDexKit;
+        final String rusVariant;
 
         Targets(
                 Method dealEndTag,
                 Method saveListToSp,
                 Method getRusWhiteList,
+                Method mediaRusConfigWhiteListGetter,
                 Method getLyricEntrance,
                 Method updatePkgActionsRule,
                 Method createActionsFromState,
                 Method loadLyricInBg,
                 Method mediaDataToBundle,
-                boolean resolvedByDexKit) {
+                boolean resolvedByDexKit,
+                String rusVariant) {
             this.dealEndTag = dealEndTag;
             this.saveListToSp = saveListToSp;
             this.getRusWhiteList = getRusWhiteList;
+            this.mediaRusConfigWhiteListGetter = mediaRusConfigWhiteListGetter;
             this.getLyricEntrance = getLyricEntrance;
             this.updatePkgActionsRule = updatePkgActionsRule;
             this.createActionsFromState = createActionsFromState;
             this.loadLyricInBg = loadLyricInBg;
             this.mediaDataToBundle = mediaDataToBundle;
             this.resolvedByDexKit = resolvedByDexKit;
+            this.rusVariant = rusVariant;
         }
     }
+
+    static final String RUS_VARIANT_OLD = "OLD";
+    static final String RUS_VARIANT_NEW = "NEW";
 }

--- a/app/src/test/java/io/github/andrealtb/lockscreenlyrics/SystemUiDexKitAdapterTest.java
+++ b/app/src/test/java/io/github/andrealtb/lockscreenlyrics/SystemUiDexKitAdapterTest.java
@@ -169,12 +169,12 @@ public class SystemUiDexKitAdapterTest {
     }
 
     @Test
-    public void whiteListGetterShapeMatchesBothGenerations() throws Exception {
-        assertTrue(SystemUiDexKitAdapter.isWhiteListGetterShape(
+    public void rusWhiteListGetterShapeMatchesOnlyLegacyName() throws Exception {
+        assertTrue(SystemUiDexKitAdapter.isRusWhiteListGetterShape(
                 method(OldRusShapes.class, "getRusWhiteList")));
-        assertTrue(SystemUiDexKitAdapter.isWhiteListGetterShape(
+        assertFalse(SystemUiDexKitAdapter.isRusWhiteListGetterShape(
                 method(NewRusShapes.class, "getWhiteList")));
-        assertFalse(SystemUiDexKitAdapter.isWhiteListGetterShape(
+        assertFalse(SystemUiDexKitAdapter.isRusWhiteListGetterShape(
                 method(OldRusShapes.class, "saveListToSP", Context.class, Set.class, Set.class, Map.class, Map.class, Map.class, Map.class, Map.class)));
     }
 
@@ -203,16 +203,16 @@ public class SystemUiDexKitAdapterTest {
         assertNull(SystemUiDexKitAdapter.findOptionalMethod(
                 NoWhiteListGetter.class,
                 "test",
-                SystemUiDexKitAdapter::isWhiteListGetterShape));
+                SystemUiDexKitAdapter::isRusWhiteListGetterShape));
     }
 
     @Test
     public void findOptionalMethodReturnsMatchingGetter() throws Exception {
         Method found = SystemUiDexKitAdapter.findOptionalMethod(
-                NewRusShapes.class,
+                OldRusShapes.class,
                 "test",
-                SystemUiDexKitAdapter::isWhiteListGetterShape);
-        assertEquals(method(NewRusShapes.class, "getWhiteList"), found);
+                SystemUiDexKitAdapter::isRusWhiteListGetterShape);
+        assertEquals(method(OldRusShapes.class, "getRusWhiteList"), found);
     }
 
     @Test

--- a/app/src/test/java/io/github/andrealtb/lockscreenlyrics/SystemUiDexKitAdapterTest.java
+++ b/app/src/test/java/io/github/andrealtb/lockscreenlyrics/SystemUiDexKitAdapterTest.java
@@ -70,6 +70,14 @@ public class SystemUiDexKitAdapterTest {
 
     /** Mirrors MediaActionPrioritySelectorImpl before/after the sixth map. */
     private static final class SelectorShapes {
+        public int getLyricEnable(String packageName) {
+            return 0;
+        }
+
+        public int getLyricEntrance(String packageName) {
+            return 0;
+        }
+
         public void updatePkgActionsRule(Map map, Map map2, Map map3, Map map4, Map map5) {
         }
 
@@ -150,6 +158,14 @@ public class SystemUiDexKitAdapterTest {
         assertTrue(SystemUiDexKitAdapter.isUpdatePkgActionsRuleShape(sixMaps));
         assertFalse(SystemUiDexKitAdapter.isUpdatePkgActionsRuleShape(
                 method(SelectorShapes.class, "staticUpdatePkgActionsRule", Map.class, Map.class, Map.class, Map.class, Map.class, Map.class)));
+    }
+
+    @Test
+    public void lyricEntranceLookupShapeSelectsOnlyEntranceDespiteEnableTwin() throws Exception {
+        Method entrance = method(SelectorShapes.class, "getLyricEntrance", String.class);
+        Method enable = method(SelectorShapes.class, "getLyricEnable", String.class);
+        assertTrue(SystemUiDexKitAdapter.isLyricEntranceLookupShape(entrance));
+        assertFalse(SystemUiDexKitAdapter.isLyricEntranceLookupShape(enable));
     }
 
     @Test

--- a/app/src/test/java/io/github/andrealtb/lockscreenlyrics/SystemUiDexKitAdapterTest.java
+++ b/app/src/test/java/io/github/andrealtb/lockscreenlyrics/SystemUiDexKitAdapterTest.java
@@ -1,0 +1,220 @@
+package io.github.andrealtb.lockscreenlyrics;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+
+import android.content.Context;
+
+import org.junit.Test;
+import org.luckypray.dexkit.query.matchers.ClassMatcher;
+
+import java.lang.reflect.Method;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+public class SystemUiDexKitAdapterTest {
+
+    /** Mirrors the ColorOS 16.0.9.x style RUS manager surface. */
+    private static final class OldRusShapes {
+        public void saveListToSP(
+                Context context,
+                Set set,
+                Set set2,
+                Map map,
+                Map map2,
+                Map map3,
+                Map map4,
+                Map map5) {
+        }
+
+        public List<String> getRusWhiteList() {
+            return null;
+        }
+
+        public static void dealEndTag(
+                String tag,
+                Set set,
+                Set set2,
+                List list,
+                List list2,
+                Map map,
+                Map map2,
+                Map map3,
+                Map map4,
+                Map map5) {
+        }
+    }
+
+    /** Mirrors the ColorOS 16.0.10.x style RUS manager surface. */
+    private static final class NewRusShapes {
+        public static void saveListToSP(
+                Context context,
+                Set set,
+                Set set2,
+                Map map,
+                Map map2,
+                Map map3,
+                Map map4,
+                Map map5,
+                Map map6,
+                int version) {
+        }
+
+        public List<String> getWhiteList() {
+            return null;
+        }
+    }
+
+    /** Mirrors MediaActionPrioritySelectorImpl before/after the sixth map. */
+    private static final class SelectorShapes {
+        public void updatePkgActionsRule(Map map, Map map2, Map map3, Map map4, Map map5) {
+        }
+
+        public void updatePkgActionsRule(
+                Map map,
+                Map map2,
+                Map map3,
+                Map map4,
+                Map map5,
+                Map map6) {
+        }
+
+        public static void staticUpdatePkgActionsRule(
+                Map map,
+                Map map2,
+                Map map3,
+                Map map4,
+                Map map5,
+                Map map6) {
+        }
+    }
+
+    private static final class NoWhiteListGetter {
+    }
+
+    private static Method method(Class<?> owner, String name, Class<?>... parameterTypes)
+            throws NoSuchMethodException {
+        return owner.getDeclaredMethod(name, parameterTypes);
+    }
+
+    @Test
+    public void saveListToSpShapeAcceptsOldInstanceEightParameterForm() throws Exception {
+        Method oldForm = method(
+                OldRusShapes.class,
+                "saveListToSP",
+                Context.class,
+                Set.class,
+                Set.class,
+                Map.class,
+                Map.class,
+                Map.class,
+                Map.class,
+                Map.class);
+        assertTrue(SystemUiDexKitAdapter.isSaveListToSpShape(oldForm));
+    }
+
+    @Test
+    public void saveListToSpShapeAcceptsNewStaticTenParameterForm() throws Exception {
+        Method newForm = method(
+                NewRusShapes.class,
+                "saveListToSP",
+                Context.class,
+                Set.class,
+                Set.class,
+                Map.class,
+                Map.class,
+                Map.class,
+                Map.class,
+                Map.class,
+                Map.class,
+                int.class);
+        assertTrue(SystemUiDexKitAdapter.isSaveListToSpShape(newForm));
+    }
+
+    @Test
+    public void saveListToSpShapeRejectsMismatchedShapes() throws Exception {
+        assertFalse(SystemUiDexKitAdapter.isSaveListToSpShape(
+                method(SelectorShapes.class, "updatePkgActionsRule", Map.class, Map.class, Map.class, Map.class, Map.class)));
+        assertFalse(SystemUiDexKitAdapter.isSaveListToSpShape(
+                method(OldRusShapes.class, "getRusWhiteList")));
+    }
+
+    @Test
+    public void updatePkgActionsRuleShapeAcceptsFiveAndSixMaps() throws Exception {
+        Method fiveMaps = method(SelectorShapes.class, "updatePkgActionsRule", Map.class, Map.class, Map.class, Map.class, Map.class);
+        Method sixMaps = method(SelectorShapes.class, "updatePkgActionsRule", Map.class, Map.class, Map.class, Map.class, Map.class, Map.class);
+        assertTrue(SystemUiDexKitAdapter.isUpdatePkgActionsRuleShape(fiveMaps));
+        assertTrue(SystemUiDexKitAdapter.isUpdatePkgActionsRuleShape(sixMaps));
+        assertFalse(SystemUiDexKitAdapter.isUpdatePkgActionsRuleShape(
+                method(SelectorShapes.class, "staticUpdatePkgActionsRule", Map.class, Map.class, Map.class, Map.class, Map.class, Map.class)));
+    }
+
+    @Test
+    public void whiteListGetterShapeMatchesBothGenerations() throws Exception {
+        assertTrue(SystemUiDexKitAdapter.isWhiteListGetterShape(
+                method(OldRusShapes.class, "getRusWhiteList")));
+        assertTrue(SystemUiDexKitAdapter.isWhiteListGetterShape(
+                method(NewRusShapes.class, "getWhiteList")));
+        assertFalse(SystemUiDexKitAdapter.isWhiteListGetterShape(
+                method(OldRusShapes.class, "saveListToSP", Context.class, Set.class, Set.class, Map.class, Map.class, Map.class, Map.class, Map.class)));
+    }
+
+    @Test
+    public void dealEndTagShapeAcceptsSharedStaticForm() throws Exception {
+        Method dealEndTag = method(
+                OldRusShapes.class,
+                "dealEndTag",
+                String.class,
+                Set.class,
+                Set.class,
+                List.class,
+                List.class,
+                Map.class,
+                Map.class,
+                Map.class,
+                Map.class,
+                Map.class);
+        assertTrue(SystemUiDexKitAdapter.isDealEndTagShape(dealEndTag));
+        assertFalse(SystemUiDexKitAdapter.isDealEndTagShape(
+                method(OldRusShapes.class, "getRusWhiteList")));
+    }
+
+    @Test
+    public void findOptionalMethodReturnsNullWhenGetterMissing() {
+        assertNull(SystemUiDexKitAdapter.findOptionalMethod(
+                NoWhiteListGetter.class,
+                "test",
+                SystemUiDexKitAdapter::isWhiteListGetterShape));
+    }
+
+    @Test
+    public void findOptionalMethodReturnsMatchingGetter() throws Exception {
+        Method found = SystemUiDexKitAdapter.findOptionalMethod(
+                NewRusShapes.class,
+                "test",
+                SystemUiDexKitAdapter::isWhiteListGetterShape);
+        assertEquals(method(NewRusShapes.class, "getWhiteList"), found);
+    }
+
+    @Test
+    public void buildAnchorMatcherSingleSetUsesAndGroup() {
+        ClassMatcher matcher = SystemUiDexKitAdapter.buildAnchorMatcher(
+                new String[]{"parseSaveXmlValue whiteList: ", "getRusWhiteList: cache is empty"});
+        assertNull(matcher.getAnyOfMatchers());
+        assertEquals(2, matcher.getUsingStringsMatcher().size());
+    }
+
+    @Test
+    public void buildAnchorMatcherMultipleSetsCombineWithAnyOf() {
+        ClassMatcher matcher = SystemUiDexKitAdapter.buildAnchorMatcher(
+                new String[]{"parseSaveXmlValue whiteList: ", "getRusWhiteList: cache is empty"},
+                new String[]{"parseSaveXmlValue whiteList: ", "parseSaveXmlValue pkgRuleMap: ", "applyConfig version="});
+        assertNull(matcher.getUsingStringsMatcher());
+        assertEquals(2, matcher.getAnyOfMatchers().size());
+        assertEquals(2, matcher.getAnyOfMatchers().get(0).getUsingStringsMatcher().size());
+        assertEquals(3, matcher.getAnyOfMatchers().get(1).getUsingStringsMatcher().size());
+    }
+}


### PR DESCRIPTION
## Summary

Fixes #23 — coloros16 金标系统最新版不生效（OPPO X9s Pro / 16.0.10.500 SystemUI
private-hook 解析失败）。

Fix SystemUI private-hook resolution on ColorOS 16.0.10.x (OPPO X9s Pro / PME110,
16.0.10.500) while keeping 16.0.9.x behavior byte-identical.

The 16.0.10.x SystemUI keeps versionName/versionCode 16.99.12/169912 but refactored the
media RUS manager: `OplusMediaRusUpdateManager.getRusWhiteList()` was removed,
`saveListToSP` became a static 10-parameter method, `updatePkgActionsRule` grew from 5 to 6
maps, the whitelist moved into a Kotlin data class `MediaRusConfig`, and a same-shaped
`getLyricEnable(String):int` sibling was added next to `getLyricEntrance`. The old DexKit
anchor set therefore returned 0 hits and the legacy reflection fallback failed on the
`saveListToSP` signature, so no SystemUI hooks were installed.

## Changes (3 commits)

- `SystemUiDexKitAdapter`: RUS manager class discovery now uses two anchor sets combined with
  `anyOf` (old set unchanged + new set `parseSaveXmlValue whiteList: ` /
  `parseSaveXmlValue pkgRuleMap: ` / `applyConfig version=`); `saveListToSp` and
  `updatePkgActionsRule` predicates accept both old and new shapes; `getRusWhiteList` is
  optional and the new build hooks `MediaRusConfig.getWhiteList()` (resolved by exact name to
  avoid Kotlin data-class `componentN` ambiguity); `getLyricEntrance` is disambiguated by name
  from `getLyricEnable`; `Targets` carries a `rusVariant` (OLD/NEW); the legacy path applies
  the same tolerance.
- `LockscreenLyricsModule`: whitelist bypass hook selects the getter by variant; resolution
  log includes `rusVariant` and the whitelist-getter label.
- New `SystemUiDexKitAdapterTest` (11 cases) covering both generations' shapes and the
  multi-anchor matcher.
- Harden optional getter resolution: the legacy whitelist getter predicate now also requires
  the exact method name, and the test-build diagnostics defaults are gated on
  `BuildConfig.DEBUG` (debug APKs keep the LSP-log-friendly logging, release stays at
  production defaults).

Affected process: `com.android.systemui`. Player-side and system_server hooks are untouched.

## Verification

- Unit tests: 42 suites / 412 tests / 0 failures (`testDebugUnitTest`), `assembleDebug` OK.
- Offline dex-level regression on the user-provided 16.0.10.500 SystemUI APK (dexdump):
  all five DexKit class queries hit exactly one class each; all eight method predicates match
  exactly one method; the old anchor set provably matches nothing on the new build.
- Device log 16.0.9.x (PJZ110): `Resolved SystemUI private hooks via DexKit
  (rusVariant=OLD | whitelistGetter=getRusWhiteList)`; full lyric pipeline OK, 0 failures.
- Device log 16.0.10.500: resolved via legacy fallback `(rusVariant=NEW |
  whitelistGetter=MediaRusConfig.getWhiteList)`; Spotify lyric pipeline OK (52-line word
  model, `itemCount=53`, render passes, keep-awake); DexKit main path now statically verified
  and pending one final device smoke test.
- Test APK (debug): `_archive/packages/2026-08-07/bridge-debug-systemui-16.0.10-rus-compat.apk`
  SHA-256 `8969350FD3DAC5FB107A6190E2FFCCCBB19E72843485D96F4840C9180D978D17`.

## Compatibility matrix

| Target | 16.0.9.x | 16.0.10.x |
| --- | --- | --- |
| RUS manager class | DexKit old anchor set | DexKit new anchor set |
| `saveListToSp` | instance, 8 params | static, 10 params |
| `updatePkgActionsRule` | 5 maps | 6 maps |
| Whitelist getter | `getRusWhiteList` | `MediaRusConfig.getWhiteList` |
| Other four hooks | unchanged | unchanged |

## Follow-ups before release

- No version bump or release files included.
- Final smoke test pending: 16.0.10.500 device should confirm the DexKit main path
  (`Resolved SystemUI private hooks via DexKit (rusVariant=NEW |
  whitelistGetter=MediaRusConfig.getWhiteList)`); issue #23 closes on merge.
