### PR TITLE
Restore full-opacity highlight for active lyric line without word timing

### DIFF
--- a/app/src/main/java/io/github/andrealtb/lockscreenlyrics/LockscreenLyricsModule.java
+++ b/app/src/main/java/io/github/andrealtb/lockscreenlyrics/LockscreenLyricsModule.java
@@ -17311,6 +17311,9 @@ public final class LockscreenLyricsModule extends XposedModule {
             canvas.drawText(line.text, x, y, inactivePaint);
             int wordIndex = line.findWordIndex(position);
             if (wordIndex < 0 || wordIndex >= line.words.size()) {
+                // Line without word timing: keep the active row at full opacity even when
+                // line-timed progress is enabled (the reveal path needs word ranges).
+                canvas.drawText(line.text, x, y, activePaint);
                 return;
             }
             WordRange activeWord = line.words.get(wordIndex);
@@ -17402,14 +17405,18 @@ public final class LockscreenLyricsModule extends XposedModule {
             float segmentWidth = drawLine.width;
             if (activeWord == null) {
                 if (activeLine) {
-                    drawFullLineOverlayIfNeeded(
-                            canvas,
-                            text,
-                            drawLine.start,
-                            drawLine.end,
-                            x,
-                            y,
-                            fullLineOverlayAmount);
+                    if (fullLineOverlayAmount > 0.001f) {
+                        drawFullLineOverlayIfNeeded(
+                                canvas,
+                                text,
+                                drawLine.start,
+                                drawLine.end,
+                                x,
+                                y,
+                                fullLineOverlayAmount);
+                    } else {
+                        canvas.drawText(text, drawLine.start, drawLine.end, x, y, activePaint);
+                    }
                 }
                 return;
             }

--- a/app/src/main/java/io/github/andrealtb/lockscreenlyrics/LockscreenLyricsModule.java
+++ b/app/src/main/java/io/github/andrealtb/lockscreenlyrics/LockscreenLyricsModule.java
@@ -17285,8 +17285,9 @@ public final class LockscreenLyricsModule extends XposedModule {
                         aodLineFillAmount);
             } else {
                 // The active line keeps full-opacity highlight even when it has no word
-                // timing to draw a reveal for; AOD low frame rate always lands here because
-                // drawProgress is false in that mode, so this also preserves the AOD fill.
+                // timing to draw a reveal for. In AOD low frame rate this branch is only
+                // reached once the fill transition completes or for wordless lines, which
+                // preserves the AOD fill behavior.
                 canvas.drawText(
                         line.text,
                         x,

--- a/app/src/main/java/io/github/andrealtb/lockscreenlyrics/LockscreenLyricsModule.java
+++ b/app/src/main/java/io/github/andrealtb/lockscreenlyrics/LockscreenLyricsModule.java
@@ -17284,12 +17284,14 @@ public final class LockscreenLyricsModule extends XposedModule {
                         y,
                         aodLineFillAmount);
             } else {
-                boolean completedAodFill = activeLine && aodLowFrameRateMode;
+                // The active line keeps full-opacity highlight even when it has no word
+                // timing to draw a reveal for; AOD low frame rate always lands here because
+                // drawProgress is false in that mode, so this also preserves the AOD fill.
                 canvas.drawText(
                         line.text,
                         x,
                         y,
-                        completedAodFill ? activePaint : inactivePaint);
+                        activeLine ? activePaint : inactivePaint);
             }
             canvas.restore();
 
@@ -17386,14 +17388,13 @@ public final class LockscreenLyricsModule extends XposedModule {
                 boolean activeLine,
                 boolean drawProgress,
                 float fullLineOverlayAmount) {
-            boolean completedAodFill = activeLine && aodLowFrameRateMode && !drawProgress;
             canvas.drawText(
                     text,
                     drawLine.start,
                     drawLine.end,
                     x,
                     y,
-                    completedAodFill ? activePaint : inactivePaint);
+                    activeLine && !drawProgress ? activePaint : inactivePaint);
             if (!drawProgress) {
                 return;
             }


### PR DESCRIPTION
## Summary

Restore the full-opacity highlight of the active lyric line for songs whose lyrics have no
word timing (plain line-timed LRC).

## Root cause

Commit `ac66d2c` ("Limit primary color to active lyric reveal", released in v3.7.0) changed
both active-line draw paths so the active line is painted with `inactivePaint` unless the
line is in AOD low-frame-rate fill mode:

- `drawCompactLine` now used `activeLine && aodLowFrameRateMode ? activePaint : inactivePaint`;
- `drawSegment` used `activeLine && aodLowFrameRateMode && !drawProgress ? activePaint : inactivePaint`.

Word-timed lyrics are unaffected because `drawProgressLine` overlays the reveal with the
active paint. Plain line-timed lyrics (no `WordRange`s) never enter the reveal path
(`findWordIndex` returns -1 and `drawProgressLine` returns early), so the active line was
drawn with the same low-opacity paint as every other line — the current-line highlight
disappeared. This is visible with Apple Music and any other player whose lyrics lack word
timing, regardless of the "普通逐行歌词进度" (`lineTimedProgressEnabled`) switch.

## Change

- `drawCompactLine` non-progress branch: paint the active line with `activePaint` again
  (the branch only runs when `!drawProgress`, so AOD low frame rate keeps its fill behavior).
- `drawSegment`: revert to `activeLine && !drawProgress ? activePaint : inactivePaint`
  (in AOD low frame rate `drawProgress` is always false, so behavior is unchanged there).
- Follow-up (commit `e997033`): when line-timed progress is enabled, wordless lines still
  entered the reveal path with no word ranges to draw, leaving the active line unhighlighted
  (pre-existing since 3.6.x). `drawProgressLine` and `drawSegment` now fall back to a
  full-opacity `activePaint` row for the active wordless line; AOD fill overlay is preserved.

## Verification

- Unit tests: 42 suites / 412 tests / 0 failures (`testDebugUnitTest`), `assembleDebug` OK.
- Debug APK:
  `_archive/packages/2026-08-08/bridge-debug-active-line-highlight-fix.apk`
  SHA-256 `B8AF1C504150D160C8B077658AFE41ED08480E2852E7611345E5DDF678948A2F`
  (supersedes `A286D54D...`).
- Device validation in progress (developer device + reporting user): expected to see the
  current line at full opacity again for plain line-timed lyrics, with no change to
  word-timed reveal or AOD low-frame-rate fill. Developer device confirmed the first
  fix; the follow-up covers the `lineTimedProgressEnabled=true` path.

Affected process: `com.android.systemui` (lyric renderer only).
