### PR TITLE
v3.7.2：播放器翻译设置重构（分播放器媒体卡翻译按钮 + 收藏兜底定位）

### DIFF
--- a/.github/release-notes/3.7.2.md
+++ b/.github/release-notes/3.7.2.md
@@ -1,0 +1,81 @@
+# ColorOS Live Lyrics Bridge v3.7.2
+
+v3.7.2 重构“播放器翻译设置”：翻译开关按钮统一占用锁屏媒体卡收藏槽位（媒体卡固定 5 个按钮，
+只能替换、不能新增），并为 QQ 音乐、原版酷狗修复此前失效的翻译按钮；新增分播放器
+“锁屏媒体卡翻译按钮”开关；设置页建立播放器卡片接入约定（按是否有翻译源显示开关），
+Spotify/Metrolist 明确显示“不支持翻译”。外部歌词 v4 协议、Provider 准入规则与既有
+AOD/渲染行为保持兼容，本次无 Provider 变更。
+
+## 播放器翻译设置重构
+
+- 代码分层：新增 `PlayerTranslationTogglePolicy`（纯决策）与
+  `TranslationToggleMediaActionBinder`（媒体卡模型操作：定位收藏、原地替换、提升、呈现、
+  点击绑定），`LockscreenLyricsModule` 不再承载媒体动作操作，只保留 Hook 入口与运行时状态。
+- 收藏定位三级兜底：`PlaybackState.CustomAction` 映射 → OPlus heart 标记
+  （`getHeartAction` / `hasHeartFromRating`）→ Rule0 列表唯一动作。QQ 音乐、原版酷狗的收藏
+  不携带 CustomAction（设备日志确认），此前翻译按钮完全失效，现经兜底恢复可用。
+- 分播放器“锁屏媒体卡翻译按钮”开关（默认开）：开 = 收藏槽位换成翻译开关；关 = 恢复播放器
+  自带收藏。开关覆盖三条按钮路径：替换收藏（QQ/酷狗/网易云/Apple/汽水/酷狗 Lite）、公开注入
+  按钮（LX/Poweramp/Cone 等，关闭时从媒体卡移除）、Salt 自带桌面歌词按钮（关闭时恢复播放器
+  自身行为）。
+- 图标加载修复：模块 `ic_translation` 改为从资源所属包 Context 直接加载；此前
+  `Icon.loadDrawable` 在 SystemUI 侧对跨包资源静默返回 null，导致按钮图标未被替换。
+- 无翻译歌曲恢复播放器自带收藏：修复媒体卡按钮视图回收复用导致“只剩 4 个按钮”的问题，
+  媒体卡始终 5 个按钮。
+
+## 设置页卡片接入约定
+
+- 播放器卡片新增 `supportsTranslation` 声明：有翻译源的播放器显示“默认显示翻译 / 锁屏媒体卡
+  翻译按钮 / 清除记忆”；无翻译源的播放器（Spotify、Metrolist）保留卡片用于检测
+  LyricProvider 安装状态，显示“不支持翻译”且不显示任何开关。
+- 新增 Metrolist 卡片，并修复其 Provider 检测（manifest `<queries>` 补充
+  `io.github.proify.lyricon.metrolistprovider`，此前 Android 11+ 包可见性导致卡片误灰置）。
+- 新播放器接入约定见 `docs/TRANSLATION_TOGGLE_INTEGRATION.md`。
+
+## 已知特殊案例
+
+- Apple Music：收藏采用评分式槽位，其渲染图标来自媒体卡模型之外的来源，静态替换不可达；
+  翻译按钮图标保留播放器自带（与翻译功能匹配），按钮功能与其余行为正常。
+
+## LyricProvider
+
+- 本次无 Provider 功能变更；全部 Provider APK 仍随 Release 附带，供按需更新。
+
+## 兼容与验证
+
+- 外部歌词协议仍为 v4；现有 Provider 的 source / playerPackage / senderPackage /
+  senderKind 静态白名单校验不变。
+- 未修改官方 Renderer 的 AOD 切换时序、`LyricsRecyclerView` prime 或普通 `TextView`
+  Hook 范围。
+- `scripts\dev.cmd bridge testDebugUnitTest assembleDebug` 通过（423 项测试 0 失败）。
+- 真机验证（OPPO 设备，debug 构建）：
+  - QQ 音乐、原版酷狗：收藏槽位变为翻译按钮、点击切换翻译行、开关关恢复收藏 —— 通过；
+  - Salt/Cone/LX/Poweramp/汽水：媒体卡翻译按钮开关开/关全部生效，Salt 图标修复为模块
+    翻译图标 —— 通过；
+  - 无翻译歌曲恢复播放器自带收藏、媒体卡保持 5 个按钮 —— 通过；
+  - Metrolist 卡片亮起并显示“不支持翻译”、无开关 —— 通过；
+  - Apple Music 图标为播放器自带（特殊案例，见上）。
+
+## 升级说明
+
+- 更新 Bridge 为 `ColorOS-Live-Lyrics-Bridge-v3.7.2.apk`；本次无 Provider 变更，无需更新
+  Provider。
+- 更新后重启对应播放器进程；如 LSPosed 仍加载旧模块，请重启设备。
+- “播放器翻译设置”新增的“锁屏媒体卡翻译按钮”默认开启；不希望收藏槽位被替换的用户可
+  逐播放器关闭。
+
+## Release 资产
+
+- `ColorOS-Live-Lyrics-Bridge-v3.7.2.apk`
+- `LyricProvider-QQMusic-v3.7.2.apk`
+- `LyricProvider-163Music-v3.7.2.apk`
+- `LyricProvider-AppleMusic-v3.7.2.apk`
+- `LyricProvider-Poweramp-v3.7.2.apk`
+- `LyricProvider-Spotify-v3.7.2.apk`
+- `LyricProvider-QiShui-v3.7.2.apk`
+- `LyricProvider-KuGou-v3.7.2.apk`
+- `LyricProvider-LXMusic-v3.7.2.apk`
+- `LyricProvider-Metrolist-v3.7.2.apk`
+- `LyricProvider-v3.7.2.zip`
+
+Provider 为独立 LSPosed 模块，只需安装自己使用的播放器对应 APK。

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -6,7 +6,7 @@ val releaseStoreFilePath = providers.environmentVariable("SIGNING_STORE_FILE").o
 val releaseStorePassword = providers.environmentVariable("KEY_STORE_PASSWORD").orNull
 val releaseKeyAlias = providers.environmentVariable("KEY_ALIAS").orNull
 val releaseKeyPassword = providers.environmentVariable("KEY_PASSWORD").orNull
-val defaultVersionName = "3.7.0"
+val defaultVersionName = "3.7.2"
 val releaseVersionName = providers.gradleProperty("releaseTag")
     .orElse(providers.environmentVariable("RELEASE_TAG"))
     .map { tag ->
@@ -38,7 +38,7 @@ android {
         applicationId = "io.github.andrealtb.lockscreenlyrics"
         minSdk = 26
         targetSdk = 35
-        versionCode = 131
+        versionCode = 132
         versionName = releaseVersionName.get()
     }
 

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -15,6 +15,7 @@
         <package android:name="io.github.proify.lyricon.spotifyprovider" />
         <package android:name="io.github.proify.lyricon.qishuiprovider" />
         <package android:name="io.github.proify.lyricon.kgprovider" />
+        <package android:name="io.github.proify.lyricon.metrolistprovider" />
     </queries>
 
     <application

--- a/app/src/main/java/io/github/andrealtb/lockscreenlyrics/LockscreenLyricsModule.java
+++ b/app/src/main/java/io/github/andrealtb/lockscreenlyrics/LockscreenLyricsModule.java
@@ -24,7 +24,6 @@ import android.graphics.Shader;
 import android.graphics.Typeface;
 import android.graphics.drawable.Drawable;
 import android.graphics.drawable.BitmapDrawable;
-import android.graphics.drawable.Icon;
 import android.media.MediaMetadata;
 import android.media.session.MediaController;
 import android.media.session.MediaSession;
@@ -107,6 +106,7 @@ public final class LockscreenLyricsModule extends XposedModule {
             "com.android.server.media.OplusMediaControlService";
     private static final String OPLUS_HISTORY_WHITELIST_METHOD =
             "isInHistoryPlayInfoWhiteList";
+    private static final String OPLUS_MEDIA_BLACKLIST_METHOD = "isInMediaBlackList";
     private static final String OPLUS_PLUGIN_CLASS_LOADER_CLASS =
             "com.android.systemui.shared.plugins.OPlusPluginClassLoader";
     private static final String LYRICS_RECYCLER_VIEW_CLASS =
@@ -146,9 +146,10 @@ public final class LockscreenLyricsModule extends XposedModule {
             "oplus-media-translation-toggle-action";
     private static final String HOOK_ID_OPLUS_HISTORY_WHITELIST =
             "oplus-media-history-whitelist-salt";
+    private static final String HOOK_ID_OPLUS_MEDIA_BLACKLIST =
+            "oplus-media-blacklist-bypass";
     private static final String HOOK_ID_AOD_MEDIA_SUPPORT =
             "oplus-aod-media-support";
-    private static final String SALT_DESKTOP_LYRIC_ACTION = "com.salt.music.desktop_lyrics";
     private static final String TRANSLATION_TOGGLE_ACTION =
             LyricInfoContract.ACTION_TOGGLE_TRANSLATION;
     private static final String EXTRA_EXTERNAL_PROTOCOL_VERSION =
@@ -200,7 +201,6 @@ public final class LockscreenLyricsModule extends XposedModule {
             LyricInfoContract.EVENT_EXTERNAL_TRACK_CHANGED;
     private static final String EVENT_EXTERNAL_LYRIC_READY =
             LyricInfoContract.EVENT_EXTERNAL_LYRIC_READY;
-    private static final String TRANSLATION_ICON_RESOURCE_NAME = "ic_translation";
     private static final String TRANSLATION_PREFERENCES_NAME = LyricUiSettings.PREFERENCES_NAME;
     private static final String TRANSLATION_PREFERENCE_KEY =
             LyricUiSettings.TRANSLATION_PREFERENCE_KEY;
@@ -299,8 +299,6 @@ public final class LockscreenLyricsModule extends XposedModule {
             LyricTimingTuningConstants.LyricGeneral.SURFACE_RENDER_PASS_MAX_FRAMES;
     private static final long LYRIC_SURFACE_RENDER_PASS_MAX_MS =
             LyricTimingTuningConstants.LyricGeneral.SURFACE_RENDER_PASS_MAX_MS;
-    private static final long TRANSLATION_TOGGLE_CONFIG_LOG_THROTTLE_MS =
-            LyricTimingTuningConstants.Translation.TOGGLE_CONFIG_LOG_THROTTLE_MS;
     private static final long LYRIC_UI_STYLE_SETTINGS_RELOAD_MS =
             LyricTimingTuningConstants.LyricGeneral.UI_STYLE_SETTINGS_RELOAD_MS;
     private static final long LYRIC_VISIBILITY_RECOVERY_FIRST_DELAY_MS =
@@ -411,10 +409,13 @@ public final class LockscreenLyricsModule extends XposedModule {
     private volatile boolean systemUiMetadataRefreshMethodUnavailableLogged;
     private volatile boolean oplusMediaPolicyHooksInstalled;
     private volatile boolean oplusHistoryWhitelistHookInstalled;
+    private volatile boolean oplusMediaBlacklistHookInstalled;
     private volatile boolean aodMediaSupportHookInstalled;
     private final Set<String> loggedOplusHistoryIntegrationPackages =
             ConcurrentHashMap.newKeySet();
     private final Set<String> loggedOplusHistoryManifestFailures =
+            ConcurrentHashMap.newKeySet();
+    private final Set<String> loggedOplusBlacklistBypassPackages =
             ConcurrentHashMap.newKeySet();
     private final Set<String> loggedAodMediaSupportPackages =
             ConcurrentHashMap.newKeySet();
@@ -422,8 +423,6 @@ public final class LockscreenLyricsModule extends XposedModule {
     private volatile boolean injectedTranslationToggleActionHookInstalled;
     private volatile boolean injectedTranslationToggleActionLogged;
     private volatile boolean injectedTranslationToggleActionFailureLogged;
-    private volatile String lastTranslationToggleConfigLogKey = "";
-    private volatile long lastTranslationToggleConfigLogAt;
     private volatile Object oplusMediaActionPrioritySelector;
     private volatile Method oplusUpdatePkgActionsRuleMethod;
     private volatile Object[] lastOplusPkgActionsRuleArgs;
@@ -435,6 +434,35 @@ public final class LockscreenLyricsModule extends XposedModule {
             ConcurrentHashMap.newKeySet();
     private final Set<String> providerDeclaredTranslationTogglePackages =
             ConcurrentHashMap.newKeySet();
+    private final Map<String, Boolean> translationButtonEnabledByPackage =
+            new ConcurrentHashMap<>();
+    private final TranslationToggleMediaActionBinder translationToggleActionBinder =
+            new TranslationToggleMediaActionBinder(new TranslationToggleMediaActionBinder.Host() {
+                @Override
+                public Context currentApplicationContext() {
+                    return LockscreenLyricsModule.currentApplicationContext();
+                }
+
+                @Override
+                public String logProcessName() {
+                    return logProcessName;
+                }
+
+                @Override
+                public boolean isLyricInfoTranslationEnabled(String packageName) {
+                    return LockscreenLyricsModule.this.isLyricInfoTranslationEnabled(packageName);
+                }
+
+                @Override
+                public void rememberTranslationIconFingerprint(Drawable drawable) {
+                    LockscreenLyricsModule.this.rememberTranslationIconFingerprint(drawable);
+                }
+
+                @Override
+                public void onTranslationToggleClicked(String packageName) {
+                    LockscreenLyricsModule.this.toggleLyricInfoTranslation(packageName);
+                }
+            });
     private final Set<String> loadedTranslationPreferencePackages =
             ConcurrentHashMap.newKeySet();
     private final Map<String, Boolean> lyricInfoTranslationEnabledByPackage =
@@ -1007,6 +1035,7 @@ public final class LockscreenLyricsModule extends XposedModule {
     @Override
     public void onSystemServerStarting(SystemServerStartingParam param) {
         installOplusHistoryWhitelistHook(param.getClassLoader());
+        installOplusMediaBlacklistBypassHook(param.getClassLoader());
     }
 
     @Override
@@ -1162,6 +1191,70 @@ public final class LockscreenLyricsModule extends XposedModule {
                     : " via manifest opt-in"));
         }
         return true;
+    }
+
+    @SuppressLint("PrivateApi") // LSPosed hook resolves the OPlus media control service by name.
+    private void installOplusMediaBlacklistBypassHook(ClassLoader classLoader) {
+        if (oplusMediaBlacklistHookInstalled) {
+            return;
+        }
+        synchronized (this) {
+            if (oplusMediaBlacklistHookInstalled) {
+                return;
+            }
+            try {
+                Class<?> serviceClass = classLoader.loadClass(
+                        OPLUS_MEDIA_CONTROL_SERVICE_CLASS);
+                Method blacklistMethod = serviceClass.getDeclaredMethod(
+                        OPLUS_MEDIA_BLACKLIST_METHOD,
+                        String.class);
+                blacklistMethod.setAccessible(true);
+                hook(blacklistMethod)
+                        .setId(HOOK_ID_OPLUS_MEDIA_BLACKLIST)
+                        .setExceptionMode(XposedInterface.ExceptionMode.PROTECTIVE)
+                        .intercept(this::onOplusMediaBlackListLookup);
+                oplusMediaBlacklistHookInstalled = true;
+                info("Hooked OPlus media blacklist bypass");
+            } catch (ClassNotFoundException | NoSuchMethodException e) {
+                info("OPlus media blacklist bypass hook is unavailable on this system");
+            } catch (Throwable t) {
+                error("Failed to hook OPlus media blacklist bypass", t);
+            }
+        }
+    }
+
+    private Object onOplusMediaBlackListLookup(
+            XposedInterface.Chain chain) throws Throwable {
+        Object originalResult = chain.proceed();
+        boolean blacklisted = Boolean.TRUE.equals(originalResult);
+        if (!blacklisted) {
+            return originalResult;
+        }
+        Object packageNameArg = chain.getArg(0);
+        if (!(packageNameArg instanceof String)
+                || TextUtils.isEmpty((String) packageNameArg)) {
+            return originalResult;
+        }
+
+        String packageName = (String) packageNameArg;
+        boolean moduleManagedPackage = isModuleManagedPlayerPackage(packageName);
+        boolean manifestOptIn = !moduleManagedPackage
+                && isOplusHistoryIntegrationDeclared(
+                        chain.getThisObject(),
+                        packageName);
+        if (!LockscreenIntegrationPolicy.shouldEnableOplusHistoryIntegration(
+                false,
+                moduleManagedPackage,
+                manifestOptIn)) {
+            return originalResult;
+        }
+        if (loggedOplusBlacklistBypassPackages.add(packageName)) {
+            info("Bypassed OPlus media blacklist for " + packageName
+                    + (moduleManagedPackage
+                    ? " via " + moduleManagedPlayerKind(packageName) + " integration"
+                    : " via manifest opt-in"));
+        }
+        return false;
     }
 
     private boolean isOplusHistoryIntegrationDeclared(
@@ -1431,7 +1524,10 @@ public final class LockscreenLyricsModule extends XposedModule {
         String packageName = packageNameArg instanceof String ? (String) packageNameArg : "";
         boolean hasTranslationAction = !TextUtils.isEmpty(packageName)
                 && controllerHasTranslationAction(controllerArg);
-        boolean canOverrideWithTranslation = canOverrideFavoriteActionWithTranslation(packageName);
+        boolean canOverrideWithTranslation =
+                PlayerTranslationTogglePolicy.canOverrideFavoriteActionWithTranslation(
+                        packageName,
+                        providerDeclaredTranslationTogglePackages);
         translationButtonDebug("createActionsFromState package=" + nullToEmpty(packageName)
                 + ", hasPublicAction=" + hasTranslationAction
                 + ", canOverride=" + canOverrideWithTranslation
@@ -1452,7 +1548,30 @@ public final class LockscreenLyricsModule extends XposedModule {
                     translationButtonDebug("createActionsFromState result for "
                             + packageName
                             + ", class=" + result.getClass().getName());
-                    replaceTranslationToggleAction(packageName, result);
+                    boolean userWantsButton = userWantsTranslationButton(packageName);
+                    translationToggleActionBinder.applyTranslationToggle(
+                            packageName,
+                            result,
+                            PlayerTranslationTogglePolicy
+                                    .shouldReplaceFavoriteActionWithTranslation(
+                                            canOverrideWithTranslation,
+                                            isCurrentLyricProviderPackage(packageName),
+                                            currentWordLyricModel == null
+                                                    ? -1
+                                                    : currentWordLyricModel.translationCount(),
+                                            currentLyricProviderPayload == null
+                                                    ? null
+                                                    : currentLyricProviderPayload.translationLyric)
+                                    && userWantsButton,
+                            userWantsButton,
+                            currentLyricProviderPackage,
+                            currentWordLyricModel == null
+                                    ? -1
+                                    : currentWordLyricModel.translationCount(),
+                            currentLyricProviderPayload == null
+                                    || currentLyricProviderPayload.translationLyric == null
+                                    ? -1
+                                    : currentLyricProviderPayload.translationLyric.length());
                 } else {
                     translationButtonDebug("createActionsFromState result null for "
                             + packageName);
@@ -1565,303 +1684,6 @@ public final class LockscreenLyricsModule extends XposedModule {
             }
             refreshedTranslationToggleRule0Packages.add(packageName);
             pendingTranslationToggleRule0Packages.remove(packageName);
-        }
-    }
-
-    private void replaceTranslationToggleAction(
-            String packageName, Object mediaButton) {
-        if (TextUtils.isEmpty(packageName) || mediaButton == null) {
-            translationButtonDebug("replace action skipped, package="
-                    + nullToEmpty(packageName)
-                    + ", mediaButton=" + (mediaButton != null));
-            return;
-        }
-
-        Object mediaButtonEx = invokeNoArgByName(mediaButton, "getMediaButtonEx");
-        Object actions = invokeNoArgByName(mediaButtonEx, "getRule0CustomActions");
-        if (!(actions instanceof List)) {
-            translationButtonDebug("replace action skipped: Rule0 actions missing"
-                    + ", package=" + packageName
-                    + ", mediaButtonEx=" + (mediaButtonEx == null
-                    ? "null"
-                    : mediaButtonEx.getClass().getName())
-                    + ", actions=" + (actions == null ? "null" : actions.getClass().getName()));
-            return;
-        }
-        List<?> actionList = (List<?>) actions;
-        translationButtonDebug("inspect Rule0 actions, package=" + packageName
-                + ", count=" + actionList.size()
-                + ", actions=" + describeRule0ActionIds(actionList));
-
-        Object overrideCandidate = null;
-        String overrideActionId = "";
-        for (Object mediaAction : actionList) {
-            Object runnable = invokeNoArgByName(mediaAction, "getAction");
-            PlaybackState.CustomAction customAction = findPlaybackStateCustomAction(runnable);
-            if (customAction == null) {
-                continue;
-            }
-
-            String actionId = customAction.getAction();
-            boolean integrationAction = TRANSLATION_TOGGLE_ACTION.equals(actionId);
-            boolean legacySaltAction = isBuiltInPlayerPackage(packageName)
-                    && SALT_DESKTOP_LYRIC_ACTION.equals(actionId);
-            if (!integrationAction && !legacySaltAction) {
-                if (overrideCandidate == null
-                        && shouldOverridePlayerActionWithTranslation(packageName)) {
-                    overrideCandidate = mediaAction;
-                    overrideActionId = actionId;
-                }
-                continue;
-            }
-
-            configureTranslationMediaAction(
-                    packageName,
-                    mediaButtonEx,
-                    actionList,
-                    mediaAction,
-                    integrationAction ? "public" : "salt-legacy",
-                    actionId);
-            return;
-        }
-        if (overrideCandidate != null) {
-            configureTranslationMediaAction(
-                    packageName,
-                    mediaButtonEx,
-                    actionList,
-                    overrideCandidate,
-                    "player-override",
-                    overrideActionId);
-        } else {
-            translationButtonDebug("no translation action candidate, package=" + packageName
-                    + ", currentProvider=" + nullToEmpty(currentLyricProviderPackage)
-                    + ", modelTranslations="
-                    + (currentWordLyricModel == null ? -1 : currentWordLyricModel.translationCount())
-                    + ", payloadTranslationChars="
-                    + (currentLyricProviderPayload == null
-                    || currentLyricProviderPayload.translationLyric == null
-                    ? -1
-                    : currentLyricProviderPayload.translationLyric.length()));
-        }
-    }
-
-    private void configureTranslationMediaAction(
-            String packageName,
-            Object mediaButtonEx,
-            List<?> actions,
-            Object mediaAction,
-            String protocol,
-            String originalActionId) {
-        boolean publicProtocol = "public".equals(protocol);
-        boolean overrideProtocol = "player-override".equals(protocol);
-        translationButtonDebug("configure translation action, package=" + packageName
-                + ", protocol=" + protocol
-                + ", originalAction=" + nullToEmpty(originalActionId)
-                + ", enabledBefore=" + isLyricInfoTranslationEnabled(packageName)
-                + ", mediaAction=" + (mediaAction == null
-                ? "null"
-                : mediaAction.getClass().getName()));
-        if (publicProtocol || overrideProtocol) {
-            promoteTranslationToggleAction(mediaButtonEx, actions, mediaAction);
-            if (!replaceMediaActionIcon(mediaAction, packageName) && publicProtocol) {
-                rememberCurrentMediaActionIcon(mediaAction);
-            }
-        } else {
-            replaceMediaActionIcon(mediaAction, packageName);
-        }
-
-        updateTranslationActionPresentation(mediaAction, packageName);
-        tryInvokeOneArgByName(mediaAction, "setAction", (Runnable) () -> {
-            boolean before = isLyricInfoTranslationEnabled(packageName);
-            translationButtonDebug("translation action clicked, package=" + packageName
-                    + ", enabledBefore=" + before);
-            toggleLyricInfoTranslation(packageName);
-            translationButtonDebug("translation action click applied, package=" + packageName
-                    + ", enabledAfter=" + isLyricInfoTranslationEnabled(packageName));
-            updateTranslationActionPresentation(mediaAction, packageName);
-        });
-        maybeLogConfiguredTranslationMediaAction(packageName, protocol, originalActionId);
-    }
-
-    private void maybeLogConfiguredTranslationMediaAction(
-            String packageName, String protocol, String originalActionId) {
-        String actionId = TextUtils.isEmpty(originalActionId) ? "" : originalActionId;
-        String logKey = packageName + "|" + protocol + "|" + actionId;
-        long now = SystemClock.elapsedRealtime();
-        if (logKey.equals(lastTranslationToggleConfigLogKey)
-                && now - lastTranslationToggleConfigLogAt
-                < TRANSLATION_TOGGLE_CONFIG_LOG_THROTTLE_MS) {
-            return;
-        }
-        lastTranslationToggleConfigLogKey = logKey;
-        lastTranslationToggleConfigLogAt = now;
-        translationButtonDebug("Configured lyricInfo translation toggle for " + packageName
-                + ", protocol=" + protocol
-                + (TextUtils.isEmpty(actionId)
-                ? ""
-                : ", originalAction=" + actionId));
-    }
-
-    private boolean shouldOverridePlayerActionWithTranslation(String packageName) {
-        if (!canOverrideFavoriteActionWithTranslation(packageName)
-                || !isCurrentLyricProviderPackage(packageName)) {
-            return false;
-        }
-        WordLyricModel model = currentWordLyricModel;
-        if (model != null && model.translationCount() > 0) {
-            return true;
-        }
-        LyricInfoContract.Payload payload = currentLyricProviderPayload;
-        return payload != null
-                && LyricInfoContract.containsTimedLrc(payload.translationLyric);
-    }
-
-    private boolean canOverrideFavoriteActionWithTranslation(String packageName) {
-        return ExternalLyricProviderSpecialCases.supportsRegisteredProviderTranslationToggle(packageName)
-                || providerDeclaredTranslationTogglePackages.contains(packageName);
-    }
-
-    private void promoteTranslationToggleAction(
-            Object mediaButtonEx, List<?> actions, Object translationAction) {
-        if (actions.isEmpty() || actions.get(0) == translationAction) {
-            return;
-        }
-        ArrayList<Object> ordered = new ArrayList<>(actions.size());
-        ordered.add(translationAction);
-        for (Object action : actions) {
-            if (action != translationAction) {
-                ordered.add(action);
-            }
-        }
-
-        tryInvokeOneArgByName(mediaButtonEx, "setRule0CustomActions", ordered);
-        Object applied = invokeNoArgByName(mediaButtonEx, "getRule0CustomActions");
-        if (!(applied instanceof List)
-                || ((List<?>) applied).isEmpty()
-                || ((List<?>) applied).get(0) != translationAction) {
-            writeFieldValue(mediaButtonEx, "rule0CustomActions", ordered);
-        }
-        translationButtonDebug("Promoted lyricInfo translation toggle within OPlus Rule0 custom actions");
-    }
-
-    private void rememberCurrentMediaActionIcon(Object mediaAction) {
-        Object icon = invokeNoArgByName(mediaAction, "getIcon");
-        if (icon instanceof Drawable) {
-            rememberTranslationIconFingerprint((Drawable) icon);
-        }
-    }
-
-    private static PlaybackState.CustomAction findPlaybackStateCustomAction(Object runnable) {
-        if (runnable == null) {
-            return null;
-        }
-        Class<?> current = runnable.getClass();
-        while (current != null) {
-            for (Field field : current.getDeclaredFields()) {
-                try {
-                    field.setAccessible(true);
-                    Object value = field.get(runnable);
-                    if (value instanceof PlaybackState.CustomAction) {
-                        return (PlaybackState.CustomAction) value;
-                    }
-                } catch (Throwable ignored) {
-                    // Continue through synthetic fields and superclass fields.
-                }
-            }
-            current = current.getSuperclass();
-        }
-        return null;
-    }
-
-    private static String describeRule0ActionIds(List<?> actions) {
-        if (actions == null) {
-            return "null";
-        }
-        StringBuilder builder = new StringBuilder("[");
-        int limit = Math.min(actions.size(), 8);
-        for (int i = 0; i < limit; i++) {
-            if (i > 0) {
-                builder.append(", ");
-            }
-            Object mediaAction = actions.get(i);
-            Object runnable = invokeNoArgByName(mediaAction, "getAction");
-            PlaybackState.CustomAction customAction = findPlaybackStateCustomAction(runnable);
-            if (customAction != null) {
-                builder.append(customAction.getAction());
-            } else {
-                builder.append(mediaAction == null ? "null" : mediaAction.getClass().getSimpleName());
-            }
-        }
-        if (actions.size() > limit) {
-            builder.append(", +").append(actions.size() - limit);
-        }
-        return builder.append(']').toString();
-    }
-
-    private boolean replaceMediaActionIcon(Object mediaAction, String packageName) {
-        Context context = currentApplicationContext();
-        if (context == null || mediaAction == null || TextUtils.isEmpty(packageName)) {
-            return false;
-        }
-        try {
-            Icon icon = findTranslationIcon(context, packageName);
-            if (icon == null) {
-                return false;
-            }
-            Drawable drawable = icon.loadDrawable(context);
-            if (drawable != null) {
-                drawable = drawable.mutate();
-                rememberTranslationIconFingerprint(drawable);
-                tryInvokeOneArgByName(mediaAction, "setIcon", drawable);
-            }
-            Object mediaActionEx = invokeNoArgByName(mediaAction, "getMediaActionEx");
-            writeFieldValue(mediaActionEx, "icon", icon);
-            return true;
-        } catch (Throwable t) {
-            error("Failed to load lyric translation icon", t);
-            return false;
-        }
-    }
-
-    private static Icon findTranslationIcon(Context context, String providerPackage) {
-        Icon providerIcon = findTranslationIconInPackage(context, providerPackage);
-        return providerIcon != null
-                ? providerIcon
-                : findTranslationIconInPackage(context, MODULE_PACKAGE);
-    }
-
-    @SuppressLint("DiscouragedApi") // Resource IDs differ between the module and provider APKs.
-    private static Icon findTranslationIconInPackage(Context context, String packageName) {
-        if (context == null || TextUtils.isEmpty(packageName)) {
-            return null;
-        }
-        try {
-            Context packageContext = context.createPackageContext(
-                    packageName,
-                    Context.CONTEXT_IGNORE_SECURITY);
-            int resourceId = packageContext.getResources().getIdentifier(
-                    TRANSLATION_ICON_RESOURCE_NAME,
-                    "drawable",
-                    packageName);
-            return resourceId == 0 ? null : Icon.createWithResource(packageName, resourceId);
-        } catch (Throwable ignored) {
-            return null;
-        }
-    }
-
-    private void updateTranslationActionPresentation(Object mediaAction, String packageName) {
-        boolean enabled = isLyricInfoTranslationEnabled(packageName);
-        translationButtonDebug("update action presentation, package=" + nullToEmpty(packageName)
-                + ", enabled=" + enabled
-                + ", action=" + (mediaAction == null ? "null" : mediaAction.getClass().getName()));
-        tryInvokeOneArgByName(
-                mediaAction,
-                "setContentDescription",
-                translationActionDescription(enabled));
-        Object icon = invokeNoArgByName(mediaAction, "getIcon");
-        if (icon instanceof Drawable) {
-            ((Drawable) icon).setAlpha(enabled ? 255 : 135);
-            ((Drawable) icon).invalidateSelf();
         }
     }
 
@@ -2284,6 +2106,28 @@ public final class LockscreenLyricsModule extends XposedModule {
                 lyricUiConfig.defaultTranslationEnabled);
     }
 
+    private boolean userWantsTranslationButton(String packageName) {
+        if (TextUtils.isEmpty(packageName)) {
+            return true;
+        }
+        Boolean cached = translationButtonEnabledByPackage.get(packageName);
+        if (cached != null) {
+            return cached;
+        }
+        Context context = currentApplicationContext();
+        if (context == null) {
+            return true;
+        }
+        boolean enabled = context.getSharedPreferences(
+                        TRANSLATION_PREFERENCES_NAME,
+                        Context.MODE_PRIVATE)
+                .getBoolean(
+                        LyricUiSettings.translationButtonKeyForPackage(packageName),
+                        true);
+        translationButtonEnabledByPackage.put(packageName, enabled);
+        return enabled;
+    }
+
     private void handlePlayerTranslationSettingsChanged(Context context, Intent intent) {
         if (context == null || intent == null) return;
         Context appContext = context.getApplicationContext();
@@ -2341,6 +2185,23 @@ public final class LockscreenLyricsModule extends XposedModule {
                         LyricUiSettings.translationDefaultKeyForPackage(packageName),
                         defaults[i]);
                 affectedPackages.add(packageName);
+            }
+        }
+
+        String[] buttonPackages = intent.getStringArrayExtra(
+                LyricUiSettings.EXTRA_TRANSLATION_BUTTON_PACKAGES);
+        boolean[] buttonValues = intent.getBooleanArrayExtra(
+                LyricUiSettings.EXTRA_TRANSLATION_BUTTON_VALUES);
+        if (buttonPackages != null && buttonValues != null
+                && buttonPackages.length == buttonValues.length) {
+            int count = Math.min(buttonPackages.length, 32);
+            for (int i = 0; i < count; i++) {
+                String packageName = nullToEmpty(buttonPackages[i]);
+                if (!PlayerTranslationSettings.isSupportedPlayerPackage(packageName)) continue;
+                editor.putBoolean(
+                        LyricUiSettings.translationButtonKeyForPackage(packageName),
+                        buttonValues[i]);
+                translationButtonEnabledByPackage.put(packageName, buttonValues[i]);
             }
         }
 
@@ -2559,11 +2420,6 @@ public final class LockscreenLyricsModule extends XposedModule {
             root.invalidate();
             root.postInvalidateOnAnimation();
         }
-    }
-
-    private static String translationActionDescription(boolean enabled) {
-        return TRANSLATION_ACTION_DESCRIPTION_PREFIX
-                + (enabled ? "\u5f00\u542f" : "\u5173\u95ed");
     }
 
     private void installSystemUiWordLyricHooks(
@@ -4490,6 +4346,7 @@ public final class LockscreenLyricsModule extends XposedModule {
         Object result;
         if (requestedVisibility == View.VISIBLE
                 && isRememberedTranslationActionView(view)
+                && stillShowsTranslationToggle(view)
                 && shouldManageTranslationActionViewVisibility()
                 && !shouldShowTranslationActionView()) {
             Object[] args = chain.getArgs().toArray();
@@ -4686,6 +4543,15 @@ public final class LockscreenLyricsModule extends XposedModule {
         if (view == null || !isRememberedTranslationActionView(view)) {
             return;
         }
+        // The media card recycles button views across tracks. If this slot no longer shows the
+        // translation toggle (for example the player's own favorite returned for a song without
+        // translation), stop managing it so the player's button stays visible.
+        if (!stillShowsTranslationToggle(view)) {
+            forgetTranslationActionViewIfRebound(view);
+            if (!isRememberedTranslationActionView(view)) {
+                return;
+            }
+        }
         // Before the immersive lyric surface is attached, leave the action at ColorOS' requested
         // visibility. Hiding it during the pre-bind phase can strand a recycled view INVISIBLE.
         if (!shouldManageTranslationActionViewVisibility()) {
@@ -4707,6 +4573,14 @@ public final class LockscreenLyricsModule extends XposedModule {
                     + ", state=" + describeTranslationButtonState()
                     + ", view=" + describeViewForLog(view));
         }
+    }
+
+    private boolean stillShowsTranslationToggle(View view) {
+        if (isTranslationActionDescription(view.getContentDescription())) {
+            return true;
+        }
+        return view instanceof ImageView
+                && looksLikeTranslationIcon(((ImageView) view).getDrawable());
     }
 
     private boolean shouldManageTranslationActionViewVisibility() {

--- a/app/src/main/java/io/github/andrealtb/lockscreenlyrics/LyricUiSettings.java
+++ b/app/src/main/java/io/github/andrealtb/lockscreenlyrics/LyricUiSettings.java
@@ -38,6 +38,10 @@ final class LyricUiSettings {
             "clear_translation_packages";
     static final String EXTRA_DEFAULT_TRANSLATION_ENABLED =
             "default_translation_enabled";
+    static final String EXTRA_TRANSLATION_BUTTON_PACKAGES =
+            "translation_button_packages";
+    static final String EXTRA_TRANSLATION_BUTTON_VALUES =
+            "translation_button_values";
     static final String EXTRA_RESULT_RECEIVER = "result_receiver";
     static final String EXTRA_CONFIG_REVISION = "config_revision";
     static final String EXTRA_SETTINGS_SOURCE = "settings_source";
@@ -60,6 +64,7 @@ final class LyricUiSettings {
     static final String SOURCE_PLAYER_TRANSLATION = "player-translation";
     static final String TRANSLATION_PREFERENCE_KEY = "lyric_info_translation_enabled";
     private static final String TRANSLATION_DEFAULT_KEY = "lyric_info_translation_default";
+    private static final String TRANSLATION_BUTTON_KEY = "lyric_info_translation_button";
     static final String EXTRA_SCROLL_SCALE_ENABLED = "scroll_scale_enabled";
     static final String EXTRA_INACTIVE_BLUR_ENABLED = "inactive_blur_enabled";
     static final String EXTRA_LINE_TIMED_PROGRESS_ENABLED = "line_timed_progress_enabled";
@@ -93,6 +98,10 @@ final class LyricUiSettings {
 
     static String translationDefaultKeyForPackage(String packageName) {
         return TRANSLATION_DEFAULT_KEY + "." + packageName;
+    }
+
+    static String translationButtonKeyForPackage(String packageName) {
+        return TRANSLATION_BUTTON_KEY + "." + packageName;
     }
 
     static LyricUiConfig withGlobalTranslationDefault(

--- a/app/src/main/java/io/github/andrealtb/lockscreenlyrics/PlayerTranslationSettings.java
+++ b/app/src/main/java/io/github/andrealtb/lockscreenlyrics/PlayerTranslationSettings.java
@@ -9,11 +9,17 @@ final class PlayerTranslationSettings {
     static final class Entry {
         final int labelRes;
         final String providerPackage;
+        final boolean supportsTranslation;
         final String[] playerPackages;
 
-        Entry(int labelRes, String providerPackage, String... playerPackages) {
+        Entry(
+                int labelRes,
+                String providerPackage,
+                boolean supportsTranslation,
+                String... playerPackages) {
             this.labelRes = labelRes;
             this.providerPackage = providerPackage;
+            this.supportsTranslation = supportsTranslation;
             this.playerPackages = playerPackages.clone();
         }
 
@@ -23,24 +29,27 @@ final class PlayerTranslationSettings {
     }
 
     private static final List<Entry> ENTRIES = Collections.unmodifiableList(Arrays.asList(
-            new Entry(R.string.player_salt, "", "com.salt.music"),
-            new Entry(R.string.player_cone, "", "ink.trantor.coneplayer", "ink.trantor.coneplayer.gp"),
-            new Entry(R.string.player_qq, "io.github.proify.lyricon.qmprovider",
+            new Entry(R.string.player_salt, "", true, "com.salt.music"),
+            new Entry(R.string.player_cone, "", true,
+                    "ink.trantor.coneplayer", "ink.trantor.coneplayer.gp"),
+            new Entry(R.string.player_qq, "io.github.proify.lyricon.qmprovider", true,
                     "com.tencent.qqmusic", "com.tencent.qqmusicpad"),
-            new Entry(R.string.player_netease, "io.github.proify.lyricon.cmprovider",
+            new Entry(R.string.player_netease, "io.github.proify.lyricon.cmprovider", true,
                     "com.netease.cloudmusic", "com.hihonor.cloudmusic"),
-            new Entry(R.string.player_apple, "io.github.proify.lyricon.amprovider",
+            new Entry(R.string.player_apple, "io.github.proify.lyricon.amprovider", true,
                     "com.apple.android.music"),
-            new Entry(R.string.player_lx, "io.github.proify.lyricon.lxprovider",
+            new Entry(R.string.player_lx, "io.github.proify.lyricon.lxprovider", true,
                     "cn.toside.music.mobile", "com.lxwalnut.music.mobile"),
-            new Entry(R.string.player_poweramp, "io.github.proify.lyricon.paprovider",
+            new Entry(R.string.player_poweramp, "io.github.proify.lyricon.paprovider", true,
                     "com.maxmpz.audioplayer"),
-            new Entry(R.string.player_spotify, "io.github.proify.lyricon.spotifyprovider",
+            new Entry(R.string.player_spotify, "io.github.proify.lyricon.spotifyprovider", false,
                     "com.spotify.music"),
-            new Entry(R.string.player_qishui, "io.github.proify.lyricon.qishuiprovider",
+            new Entry(R.string.player_qishui, "io.github.proify.lyricon.qishuiprovider", true,
                     "com.luna.music"),
-            new Entry(R.string.player_kugou, "io.github.proify.lyricon.kgprovider",
-                    "com.kugou.android", "com.kugou.android.lite")
+            new Entry(R.string.player_kugou, "io.github.proify.lyricon.kgprovider", true,
+                    "com.kugou.android", "com.kugou.android.lite"),
+            new Entry(R.string.player_metrolist, "io.github.proify.lyricon.metrolistprovider",
+                    false, "com.metrolist.music")
     ));
 
     private PlayerTranslationSettings() {

--- a/app/src/main/java/io/github/andrealtb/lockscreenlyrics/PlayerTranslationSettingsActivity.java
+++ b/app/src/main/java/io/github/andrealtb/lockscreenlyrics/PlayerTranslationSettingsActivity.java
@@ -108,13 +108,22 @@ public final class PlayerTranslationSettingsActivity extends SettingsBaseActivit
             TextView title = text(playerName, 13.5f, settingsTextColor());
             title.setTypeface(Typeface.DEFAULT, Typeface.BOLD);
             labels.addView(title, matchWrap());
-            TextView status = text(
-                    entry.isBuiltIn()
-                            ? getString(R.string.sub_trans_status_builtin)
-                            : available
-                            ? getString(R.string.sub_trans_status_detected)
-                            : getString(R.string.sub_trans_status_missing),
-                    10.5f,
+            String statusText;
+            if (!entry.supportsTranslation) {
+                statusText = getString(R.string.sub_trans_status_unsupported);
+                if (!entry.isBuiltIn() && !available) {
+                    statusText = statusText
+                            + " · "
+                            + getString(R.string.sub_trans_status_missing);
+                }
+            } else {
+                statusText = entry.isBuiltIn()
+                        ? getString(R.string.sub_trans_status_builtin)
+                        : available
+                        ? getString(R.string.sub_trans_status_detected)
+                        : getString(R.string.sub_trans_status_missing);
+            }
+            TextView status = text(statusText, 10.5f,
                     available ? 0xFF5F6368 : 0xFF9AA0A6);
             status.setPadding(0, dp(2), 0, 0);
             labels.addView(status, matchWrap());
@@ -123,28 +132,47 @@ public final class PlayerTranslationSettingsActivity extends SettingsBaseActivit
                     LinearLayout.LayoutParams.WRAP_CONTENT,
                     1f));
             card.addView(header, matchWrap());
-            boolean defaultEnabled = preferences.getBoolean(
-                    LyricUiSettings.translationDefaultKeyForPackage(entry.playerPackages[0]),
-                    config.defaultTranslationEnabled);
-            MaterialSwitch defaultMaterialSwitch = toggle(
-                    getString(R.string.sub_trans_default),
-                    defaultEnabled);
-            defaultMaterialSwitch.setPadding(0, 0, 0, 0);
-            Button clear = button(getString(R.string.sub_trans_clear));
-            clear.setOnClickListener(view -> {
-                for (String packageName : entry.playerPackages) {
-                    clearRequestedPackages.add(packageName);
-                }
-                Toast.makeText(this,
-                        getString(R.string.sub_trans_clear_toast, playerName),
-                        Toast.LENGTH_SHORT).show();
-            });
-            defaultMaterialSwitch.setEnabled(available);
-            clear.setEnabled(available);
+            MaterialSwitch defaultMaterialSwitch = null;
+            MaterialSwitch buttonMaterialSwitch = null;
+            if (entry.supportsTranslation) {
+                boolean defaultEnabled = preferences.getBoolean(
+                        LyricUiSettings.translationDefaultKeyForPackage(
+                                entry.playerPackages[0]),
+                        config.defaultTranslationEnabled);
+                defaultMaterialSwitch = toggle(
+                        getString(R.string.sub_trans_default),
+                        defaultEnabled);
+                defaultMaterialSwitch.setPadding(0, 0, 0, 0);
+                boolean buttonEnabled = preferences.getBoolean(
+                        LyricUiSettings.translationButtonKeyForPackage(
+                                entry.playerPackages[0]),
+                        true);
+                buttonMaterialSwitch = toggle(
+                        getString(R.string.sub_trans_button),
+                        buttonEnabled);
+                buttonMaterialSwitch.setPadding(0, 0, 0, 0);
+                Button clear = button(getString(R.string.sub_trans_clear));
+                clear.setOnClickListener(view -> {
+                    for (String packageName : entry.playerPackages) {
+                        clearRequestedPackages.add(packageName);
+                    }
+                    Toast.makeText(this,
+                            getString(R.string.sub_trans_clear_toast, playerName),
+                            Toast.LENGTH_SHORT).show();
+                });
+                defaultMaterialSwitch.setEnabled(available);
+                buttonMaterialSwitch.setEnabled(available);
+                clear.setEnabled(available);
+                card.addView(defaultMaterialSwitch, matchWrap());
+                card.addView(buttonMaterialSwitch, matchWrap());
+                card.addView(clear, matchWrap());
+            }
             card.setAlpha(available ? 1f : 0.48f);
-            card.addView(defaultMaterialSwitch, matchWrap());
-            card.addView(clear, matchWrap());
-            entryViews.add(new EntryView(entry, defaultMaterialSwitch, available));
+            entryViews.add(new EntryView(
+                    entry,
+                    defaultMaterialSwitch,
+                    buttonMaterialSwitch,
+                    available));
             content.addView(card, marginBottom(dp(12)));
             entryIndex++;
         }
@@ -194,22 +222,34 @@ public final class PlayerTranslationSettingsActivity extends SettingsBaseActivit
 
         ArrayList<String> packages = new ArrayList<>();
         ArrayList<Boolean> defaults = new ArrayList<>();
+        ArrayList<String> buttonPackages = new ArrayList<>();
+        ArrayList<Boolean> buttonValues = new ArrayList<>();
         SharedPreferences.Editor editor = preferences.edit();
         for (EntryView entryView : entryViews) {
-            if (!entryView.available) continue;
+            if (!entryView.available || entryView.defaultMaterialSwitch == null) continue;
             boolean enabled = entryView.defaultMaterialSwitch.isChecked();
+            boolean buttonEnabled = entryView.buttonMaterialSwitch.isChecked();
             for (String packageName : entryView.entry.playerPackages) {
                 packages.add(packageName);
                 defaults.add(enabled);
                 editor.putBoolean(
                         LyricUiSettings.translationDefaultKeyForPackage(packageName),
                         enabled);
+                buttonPackages.add(packageName);
+                buttonValues.add(buttonEnabled);
+                editor.putBoolean(
+                        LyricUiSettings.translationButtonKeyForPackage(packageName),
+                        buttonEnabled);
             }
         }
         editor.apply();
 
         boolean[] defaultValues = new boolean[defaults.size()];
         for (int i = 0; i < defaults.size(); i++) defaultValues[i] = defaults.get(i);
+        boolean[] buttonValueArray = new boolean[buttonValues.size()];
+        for (int i = 0; i < buttonValues.size(); i++) {
+            buttonValueArray[i] = buttonValues.get(i);
+        }
         long revision = LyricUiSettings.newSettingsRevision();
         pendingSettingsRevision = revision;
         Intent intent = new Intent(LyricUiSettings.ACTION_PLAYER_TRANSLATION_SETTINGS_CHANGED)
@@ -223,6 +263,12 @@ public final class PlayerTranslationSettingsActivity extends SettingsBaseActivit
                 .putExtra(
                         LyricUiSettings.EXTRA_PLAYER_TRANSLATION_DEFAULTS,
                         defaultValues)
+                .putExtra(
+                        LyricUiSettings.EXTRA_TRANSLATION_BUTTON_PACKAGES,
+                        buttonPackages.toArray(new String[0]))
+                .putExtra(
+                        LyricUiSettings.EXTRA_TRANSLATION_BUTTON_VALUES,
+                        buttonValueArray)
                 .putExtra(
                         LyricUiSettings.EXTRA_CLEAR_TRANSLATION_PACKAGES,
                         clearRequestedPackages.toArray(new String[0]))
@@ -319,14 +365,17 @@ public final class PlayerTranslationSettingsActivity extends SettingsBaseActivit
     private static final class EntryView {
         final PlayerTranslationSettings.Entry entry;
         final MaterialSwitch defaultMaterialSwitch;
+        final MaterialSwitch buttonMaterialSwitch;
         final boolean available;
 
         EntryView(
                 PlayerTranslationSettings.Entry entry,
                 MaterialSwitch defaultMaterialSwitch,
+                MaterialSwitch buttonMaterialSwitch,
                 boolean available) {
             this.entry = entry;
             this.defaultMaterialSwitch = defaultMaterialSwitch;
+            this.buttonMaterialSwitch = buttonMaterialSwitch;
             this.available = available;
         }
     }

--- a/app/src/main/java/io/github/andrealtb/lockscreenlyrics/PlayerTranslationTogglePolicy.java
+++ b/app/src/main/java/io/github/andrealtb/lockscreenlyrics/PlayerTranslationTogglePolicy.java
@@ -1,0 +1,38 @@
+package io.github.andrealtb.lockscreenlyrics;
+
+import java.util.Set;
+
+/**
+ * Decides whether a player's favorite media-card slot may be replaced with the lyric translation
+ * toggle. Pure decision logic; every SystemUI media-model operation lives in
+ * {@link TranslationToggleMediaActionBinder}.
+ */
+final class PlayerTranslationTogglePolicy {
+
+    private PlayerTranslationTogglePolicy() {
+    }
+
+    static boolean canOverrideFavoriteActionWithTranslation(
+            String packageName,
+            Set<String> providerDeclaredTranslationTogglePackages) {
+        return ExternalLyricProviderSpecialCases
+                .supportsRegisteredProviderTranslationToggle(packageName)
+                || (providerDeclaredTranslationTogglePackages != null
+                && providerDeclaredTranslationTogglePackages.contains(packageName));
+    }
+
+    static boolean shouldReplaceFavoriteActionWithTranslation(
+            boolean canOverrideFavoriteAction,
+            boolean isCurrentLyricProviderPackage,
+            int modelTranslationCount,
+            String payloadTranslationLyric) {
+        if (!canOverrideFavoriteAction || !isCurrentLyricProviderPackage) {
+            return false;
+        }
+        if (modelTranslationCount > 0) {
+            return true;
+        }
+        return payloadTranslationLyric != null
+                && LyricInfoContract.containsTimedLrc(payloadTranslationLyric);
+    }
+}

--- a/app/src/main/java/io/github/andrealtb/lockscreenlyrics/TranslationToggleMediaActionBinder.java
+++ b/app/src/main/java/io/github/andrealtb/lockscreenlyrics/TranslationToggleMediaActionBinder.java
@@ -1,0 +1,510 @@
+package io.github.andrealtb.lockscreenlyrics;
+
+import android.content.Context;
+import android.content.res.Resources;
+import android.graphics.drawable.Drawable;
+import android.graphics.drawable.Icon;
+import android.media.session.PlaybackState;
+import android.os.SystemClock;
+import android.util.Log;
+
+import java.lang.reflect.Field;
+import java.lang.reflect.Method;
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Owns every OPlus media-card model operation behind the lyric translation toggle: locating the
+ * player's favorite action (PlaybackState.CustomAction mapping, the OPlus heart marker, or the
+ * single-action Rule0 fallback), replacing it in place, promoting it within the Rule0 custom
+ * actions and presenting the enabled state.
+ *
+ * <p>Decision logic lives in {@link PlayerTranslationTogglePolicy}; this class only executes on
+ * the media model objects owned by SystemUI, so the logic stays out of
+ * {@link LockscreenLyricsModule}.</p>
+ */
+final class TranslationToggleMediaActionBinder {
+
+    interface Host {
+        Context currentApplicationContext();
+
+        String logProcessName();
+
+        boolean isLyricInfoTranslationEnabled(String packageName);
+
+        void rememberTranslationIconFingerprint(Drawable drawable);
+
+        void onTranslationToggleClicked(String packageName);
+    }
+
+    private static final String TRANSLATION_ICON_RESOURCE_NAME = "ic_translation";
+    private static final String TRANSLATION_ACTION_DESCRIPTION_PREFIX = "翻译：";
+    private static final String SALT_DESKTOP_LYRIC_ACTION = "com.salt.music.desktop_lyrics";
+    private static final boolean TRANSLATION_BUTTON_DIAGNOSTICS_ENABLED = BuildConfig.DEBUG;
+
+    private final Host host;
+    private String lastTranslationToggleConfigLogKey = "";
+    private long lastTranslationToggleConfigLogAt;
+
+    TranslationToggleMediaActionBinder(Host host) {
+        this.host = host;
+    }
+
+    void applyTranslationToggle(
+            String packageName,
+            Object mediaButton,
+            boolean allowOverride,
+            boolean userWantsButton,
+            String currentProviderPackage,
+            int modelTranslationCount,
+            int payloadTranslationChars) {
+        if (isEmpty(packageName) || mediaButton == null) {
+            debug("replace action skipped, package=" + nullToEmpty(packageName)
+                    + ", mediaButton=" + (mediaButton != null));
+            return;
+        }
+
+        Object mediaButtonEx = invokeNoArgByName(mediaButton, "getMediaButtonEx");
+        Object actions = invokeNoArgByName(mediaButtonEx, "getRule0CustomActions");
+        if (!(actions instanceof List)) {
+            debug("replace action skipped: Rule0 actions missing"
+                    + ", package=" + nullToEmpty(packageName)
+                    + ", mediaButtonEx=" + (mediaButtonEx == null
+                    ? "null"
+                    : mediaButtonEx.getClass().getName())
+                    + ", actions=" + (actions == null
+                    ? "null"
+                    : actions.getClass().getName()));
+            return;
+        }
+        List<?> actionList = (List<?>) actions;
+        debug("inspect Rule0 actions, package=" + nullToEmpty(packageName)
+                + ", count=" + actionList.size()
+                + ", actions=" + describeRule0ActionIds(actionList));
+
+        Object overrideCandidate = null;
+        String overrideActionId = "";
+        for (Object mediaAction : actionList) {
+            Object runnable = invokeNoArgByName(mediaAction, "getAction");
+            PlaybackState.CustomAction customAction = findPlaybackStateCustomAction(runnable);
+            if (customAction == null) {
+                continue;
+            }
+            String actionId = customAction.getAction();
+            boolean integrationAction =
+                    LyricInfoContract.ACTION_TOGGLE_TRANSLATION.equals(actionId);
+            boolean legacySaltAction = SALT_DESKTOP_LYRIC_ACTION.equals(actionId);
+            if (!integrationAction && !legacySaltAction) {
+                if (overrideCandidate == null && allowOverride) {
+                    overrideCandidate = mediaAction;
+                    overrideActionId = actionId;
+                }
+                continue;
+            }
+            if (!userWantsButton) {
+                if (integrationAction) {
+                    removeRule0Action(mediaButtonEx, actionList, mediaAction);
+                    debug("Removed lyricInfo translation toggle action, package="
+                            + nullToEmpty(packageName)
+                            + " (button disabled by user)");
+                } else {
+                    debug("Left player desktop-lyric action untouched, package="
+                            + nullToEmpty(packageName)
+                            + " (button disabled by user)");
+                }
+                return;
+            }
+            configure(
+                    mediaButtonEx,
+                    actionList,
+                    mediaAction,
+                    packageName,
+                    integrationAction ? "public" : "salt-legacy",
+                    actionId);
+            return;
+        }
+        if (overrideCandidate == null) {
+            overrideCandidate = findOverrideFallback(mediaButtonEx, actionList);
+            overrideActionId = "";
+        }
+        if (overrideCandidate != null && allowOverride) {
+            configure(
+                    mediaButtonEx,
+                    actionList,
+                    overrideCandidate,
+                    packageName,
+                    "player-override",
+                    overrideActionId);
+            return;
+        }
+        debug("no translation action candidate | package=" + nullToEmpty(packageName)
+                + ", currentProvider=" + nullToEmpty(currentProviderPackage)
+                + ", modelTranslations=" + modelTranslationCount
+                + ", payloadTranslationChars=" + payloadTranslationChars);
+    }
+
+    private void removeRule0Action(Object mediaButtonEx, List<?> actions, Object target) {
+        if (actions == null || actions.isEmpty() || target == null) {
+            return;
+        }
+        ArrayList<Object> remaining = new ArrayList<>(actions.size());
+        boolean removed = false;
+        for (Object action : actions) {
+            if (action == target) {
+                removed = true;
+            } else {
+                remaining.add(action);
+            }
+        }
+        if (!removed) {
+            return;
+        }
+        tryInvokeOneArgByName(mediaButtonEx, "setRule0CustomActions", remaining);
+        writeFieldValue(mediaButtonEx, "rule0CustomActions", remaining);
+    }
+
+    /**
+     * QQ Music and KuGou (original) expose their favorite without a PlaybackState.CustomAction
+     * backing the Rule0 action. Locate it through the OPlus heart marker first, then fall back to
+     * the single-action Rule0 list those players keep.
+     */
+    private Object findOverrideFallback(Object mediaButtonEx, List<?> actions) {
+        Object heartAction = invokeNoArgByName(mediaButtonEx, "getHeartAction");
+        if (heartAction != null) {
+            debug("override fallback located favorite via OPlus heart action"
+                    + ", action=" + heartAction.getClass().getName());
+            return heartAction;
+        }
+        if (actions != null && actions.size() == 1) {
+            debug("override fallback located single Rule0 action");
+            return actions.get(0);
+        }
+        return null;
+    }
+
+    private void configure(
+            Object mediaButtonEx,
+            List<?> actions,
+            Object mediaAction,
+            String packageName,
+            String protocol,
+            String originalActionId) {
+        boolean publicProtocol = "public".equals(protocol);
+        boolean overrideProtocol = "player-override".equals(protocol);
+        boolean enabledBefore = host.isLyricInfoTranslationEnabled(packageName);
+        debug("configure translation action, package=" + nullToEmpty(packageName)
+                + ", protocol=" + protocol
+                + ", originalAction=" + nullToEmpty(originalActionId)
+                + ", enabledBefore=" + enabledBefore
+                + ", mediaAction=" + (mediaAction == null
+                ? "null"
+                : mediaAction.getClass().getName()));
+        if (publicProtocol || overrideProtocol) {
+            promoteTranslationToggleAction(mediaButtonEx, actions, mediaAction);
+            if (!replaceMediaActionIcon(mediaAction, packageName) && publicProtocol) {
+                rememberCurrentMediaActionIcon(mediaAction);
+            }
+        } else {
+            replaceMediaActionIcon(mediaAction, packageName);
+        }
+
+        present(mediaAction, packageName);
+        tryInvokeOneArgByName(mediaAction, "setAction", (Runnable) () -> {
+            boolean before = host.isLyricInfoTranslationEnabled(packageName);
+            debug("translation action clicked, package=" + nullToEmpty(packageName)
+                    + ", enabledBefore=" + before);
+            host.onTranslationToggleClicked(packageName);
+            present(mediaAction, packageName);
+            debug("translation action click applied, package=" + nullToEmpty(packageName)
+                    + ", enabledAfter=" + host.isLyricInfoTranslationEnabled(packageName));
+        });
+        maybeLogConfiguredTranslationMediaAction(packageName, protocol, originalActionId);
+    }
+
+    private void promoteTranslationToggleAction(
+            Object mediaButtonEx, List<?> actions, Object translationAction) {
+        if (actions.isEmpty() || actions.get(0) == translationAction) {
+            return;
+        }
+        ArrayList<Object> ordered = new ArrayList<>(actions.size());
+        ordered.add(translationAction);
+        for (Object action : actions) {
+            if (action != translationAction) {
+                ordered.add(action);
+            }
+        }
+        tryInvokeOneArgByName(mediaButtonEx, "setRule0CustomActions", ordered);
+        Object applied = invokeNoArgByName(mediaButtonEx, "getRule0CustomActions");
+        if (!(applied instanceof List)
+                || ((List<?>) applied).isEmpty()
+                || ((List<?>) applied).get(0) != translationAction) {
+            writeFieldValue(mediaButtonEx, "rule0CustomActions", ordered);
+        }
+        debug("Promoted lyricInfo translation toggle within OPlus Rule0 custom actions");
+    }
+
+    private void rememberCurrentMediaActionIcon(Object mediaAction) {
+        Object icon = invokeNoArgByName(mediaAction, "getIcon");
+        if (icon instanceof Drawable) {
+            host.rememberTranslationIconFingerprint((Drawable) icon);
+        }
+    }
+
+    private boolean replaceMediaActionIcon(Object mediaAction, String packageName) {
+        Context context = host.currentApplicationContext();
+        if (context == null || mediaAction == null || isEmpty(packageName)) {
+            return false;
+        }
+        try {
+            TranslationIcon translationIcon = findTranslationIcon(context, packageName);
+            debug("replace media action icon, package=" + nullToEmpty(packageName)
+                    + ", foundIcon=" + (translationIcon != null)
+                    + ", action=" + mediaAction.getClass().getName());
+            if (translationIcon == null) {
+                return false;
+            }
+            Drawable drawable = translationIcon.drawable;
+            debug("replace media action icon drawable=" + (drawable != null)
+                    + ", action=" + mediaAction.getClass().getName());
+            if (drawable != null) {
+                drawable = drawable.mutate();
+                host.rememberTranslationIconFingerprint(drawable);
+                tryInvokeOneArgByName(mediaAction, "setIcon", drawable);
+                Object appliedIcon = invokeNoArgByName(mediaAction, "getIcon");
+                debug("replace media action icon applied=" + (appliedIcon == drawable)
+                        + ", appliedClass=" + (appliedIcon == null
+                        ? "null"
+                        : appliedIcon.getClass().getName()));
+            }
+            Object mediaActionEx = invokeNoArgByName(mediaAction, "getMediaActionEx");
+            writeFieldValue(mediaActionEx, "icon", translationIcon.icon);
+            return true;
+        } catch (Throwable t) {
+            Log.e("LockscreenLyrics", formatLog(
+                    "icon-failure",
+                    "Failed to load lyric translation icon: " + t));
+            return false;
+        }
+    }
+
+    private static final class TranslationIcon {
+        final Icon icon;
+        final Drawable drawable;
+
+        TranslationIcon(Icon icon, Drawable drawable) {
+            this.icon = icon;
+            this.drawable = drawable;
+        }
+    }
+
+    private static TranslationIcon findTranslationIcon(
+            Context context, String providerPackage) {
+        TranslationIcon providerIcon = findTranslationIconInPackage(context, providerPackage);
+        return providerIcon != null
+                ? providerIcon
+                : findTranslationIconInPackage(context, "io.github.andrealtb.lockscreenlyrics");
+    }
+
+    private static TranslationIcon findTranslationIconInPackage(
+            Context context, String packageName) {
+        if (context == null || isEmpty(packageName)) {
+            return null;
+        }
+        try {
+            Context packageContext = context.createPackageContext(
+                    packageName,
+                    Context.CONTEXT_IGNORE_SECURITY);
+            Resources resources = packageContext.getResources();
+            int resourceId = resources.getIdentifier(
+                    TRANSLATION_ICON_RESOURCE_NAME,
+                    "drawable",
+                    packageName);
+            if (resourceId == 0) {
+                return null;
+            }
+            Drawable drawable = packageContext.getDrawable(resourceId);
+            return new TranslationIcon(
+                    Icon.createWithResource(packageName, resourceId),
+                    drawable);
+        } catch (Throwable ignored) {
+            return null;
+        }
+    }
+
+    private void present(Object mediaAction, String packageName) {
+        boolean enabled = host.isLyricInfoTranslationEnabled(packageName);
+        debug("update action presentation, package=" + nullToEmpty(packageName)
+                + ", enabled=" + enabled
+                + ", action=" + (mediaAction == null
+                ? "null"
+                : mediaAction.getClass().getName()));
+        tryInvokeOneArgByName(
+                mediaAction,
+                "setContentDescription",
+                translationActionDescription(enabled));
+        Object icon = invokeNoArgByName(mediaAction, "getIcon");
+        if (icon instanceof Drawable) {
+            ((Drawable) icon).setAlpha(enabled ? 255 : 135);
+            ((Drawable) icon).invalidateSelf();
+        }
+    }
+
+    private static String translationActionDescription(boolean enabled) {
+        return TRANSLATION_ACTION_DESCRIPTION_PREFIX
+                + (enabled ? "开启" : "关闭");
+    }
+
+    private void maybeLogConfiguredTranslationMediaAction(
+            String packageName, String protocol, String originalActionId) {
+        String actionId = isEmpty(originalActionId) ? "" : originalActionId;
+        String logKey = packageName + "|" + protocol + "|" + actionId;
+        long now = SystemClock.elapsedRealtime();
+        if (logKey.equals(lastTranslationToggleConfigLogKey)
+                && now - lastTranslationToggleConfigLogAt
+                < LyricTimingTuningConstants.Translation.TOGGLE_CONFIG_LOG_THROTTLE_MS) {
+            return;
+        }
+        lastTranslationToggleConfigLogKey = logKey;
+        lastTranslationToggleConfigLogAt = now;
+        debug("Configured lyricInfo translation toggle for " + packageName
+                + ", protocol=" + protocol
+                + (isEmpty(actionId)
+                ? ""
+                : ", originalAction=" + actionId));
+    }
+
+    private static PlaybackState.CustomAction findPlaybackStateCustomAction(Object runnable) {
+        if (runnable == null) {
+            return null;
+        }
+        Class<?> current = runnable.getClass();
+        while (current != null) {
+            for (Field field : current.getDeclaredFields()) {
+                try {
+                    field.setAccessible(true);
+                    Object value = field.get(runnable);
+                    if (value instanceof PlaybackState.CustomAction) {
+                        return (PlaybackState.CustomAction) value;
+                    }
+                } catch (Throwable ignored) {
+                    // Continue through synthetic fields and superclass fields.
+                }
+            }
+            current = current.getSuperclass();
+        }
+        return null;
+    }
+
+    private static String describeRule0ActionIds(List<?> actions) {
+        if (actions == null) {
+            return "null";
+        }
+        StringBuilder builder = new StringBuilder("[");
+        int limit = Math.min(actions.size(), 8);
+        for (int i = 0; i < limit; i++) {
+            if (i > 0) {
+                builder.append(", ");
+            }
+            Object mediaAction = actions.get(i);
+            Object runnable = invokeNoArgByName(mediaAction, "getAction");
+            PlaybackState.CustomAction customAction = findPlaybackStateCustomAction(runnable);
+            if (customAction != null) {
+                builder.append(customAction.getAction());
+            } else {
+                builder.append(mediaAction == null
+                        ? "null"
+                        : mediaAction.getClass().getSimpleName());
+            }
+        }
+        if (actions.size() > limit) {
+            builder.append(", +").append(actions.size() - limit);
+        }
+        return builder.append(']').toString();
+    }
+
+    private static Object invokeNoArgByName(Object target, String methodName) {
+        if (target == null || isEmpty(methodName)) {
+            return null;
+        }
+        Class<?> current = target.getClass();
+        while (current != null) {
+            try {
+                Method method = current.getDeclaredMethod(methodName);
+                method.setAccessible(true);
+                return method.invoke(target);
+            } catch (NoSuchMethodException ignored) {
+                current = current.getSuperclass();
+            } catch (Throwable ignored) {
+                return null;
+            }
+        }
+        return null;
+    }
+
+    private static void tryInvokeOneArgByName(
+            Object target, String methodName, Object arg) {
+        if (target == null || isEmpty(methodName)) {
+            return;
+        }
+        Class<?> current = target.getClass();
+        while (current != null) {
+            Method[] methods = current.getDeclaredMethods();
+            for (Method method : methods) {
+                if (!methodName.equals(method.getName())
+                        || method.getParameterTypes().length != 1) {
+                    continue;
+                }
+                try {
+                    method.setAccessible(true);
+                    method.invoke(target, arg);
+                    return;
+                } catch (Throwable ignored) {
+                    // Try another overload or superclass implementation.
+                }
+            }
+            current = current.getSuperclass();
+        }
+    }
+
+    private static void writeFieldValue(Object target, String fieldName, Object value) {
+        if (target == null || isEmpty(fieldName)) {
+            return;
+        }
+        Class<?> current = target.getClass();
+        while (current != null) {
+            try {
+                Field field = current.getDeclaredField(fieldName);
+                field.setAccessible(true);
+                field.set(target, value);
+                return;
+            } catch (NoSuchFieldException ignored) {
+                current = current.getSuperclass();
+            } catch (Throwable ignored) {
+                return;
+            }
+        }
+    }
+
+    private void debug(String message) {
+        if (!TRANSLATION_BUTTON_DIAGNOSTICS_ENABLED) {
+            return;
+        }
+        Log.i("LockscreenLyrics", formatLog("button", message));
+    }
+
+    private String formatLog(String event, String message) {
+        return LyricLogFormatter.format(
+                host.logProcessName(),
+                LyricLogFormatter.Area.TRANSLATION,
+                event,
+                message);
+    }
+
+    private static boolean isEmpty(String value) {
+        return value == null || value.isEmpty();
+    }
+
+    private static String nullToEmpty(String value) {
+        return value == null ? "" : value;
+    }
+}

--- a/app/src/main/res/values-en/strings.xml
+++ b/app/src/main/res/values-en/strings.xml
@@ -28,15 +28,18 @@
     <string name="player_spotify">Spotify</string>
     <string name="player_qishui">QiShui Music</string>
     <string name="player_kugou">KuGou Music</string>
+    <string name="player_metrolist">Metrolist</string>
     <!-- Sub page: player translation settings -->
     <string name="sub_trans_desc">The player\'s own translation toggle takes priority over these defaults. You can clear per-player memory individually.</string>
     <string name="sub_trans_fallback">Default translation for other players</string>
     <string name="sub_trans_default">Default show translation</string>
+    <string name="sub_trans_button">Media-card translation button</string>
     <string name="sub_trans_clear">Clear this player\'s translation memory</string>
     <string name="sub_trans_clear_toast">Will clear %1$s memory on save</string>
     <string name="sub_trans_status_builtin">Built-in adapter</string>
     <string name="sub_trans_status_detected">LyricProvider detected</string>
     <string name="sub_trans_status_missing">LyricProvider not installed</string>
+    <string name="sub_trans_status_unsupported">No translation support</string>
     <string name="sub_trans_save">Apply &amp; save</string>
     <string name="sub_trans_saved">Saved, waiting for SystemUI confirmation</string>
     <string name="sub_trans_saved_pending">Saved, but SystemUI did not confirm; check that the module is enabled</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -28,15 +28,18 @@
     <string name="player_spotify">Spotify</string>
     <string name="player_qishui">汽水音乐</string>
     <string name="player_kugou">酷狗音乐</string>
+    <string name="player_metrolist">Metrolist</string>
     <!-- 子页面：播放器翻译设置 -->
     <string name="sub_trans_desc">播放器自己的翻译按钮选择会优先于这里的默认值；可按播放器单独清除该记忆。</string>
     <string name="sub_trans_fallback">其他播放器默认显示翻译</string>
     <string name="sub_trans_default">默认显示翻译</string>
+    <string name="sub_trans_button">锁屏媒体卡翻译按钮</string>
     <string name="sub_trans_clear">清除该播放器的翻译记忆</string>
     <string name="sub_trans_clear_toast">将在保存时清除 %1$s 的记忆</string>
     <string name="sub_trans_status_builtin">内置适配</string>
     <string name="sub_trans_status_detected">已检测到 LyricProvider</string>
     <string name="sub_trans_status_missing">未安装对应 LyricProvider</string>
+    <string name="sub_trans_status_unsupported">不支持翻译</string>
     <string name="sub_trans_save">保存并应用</string>
     <string name="sub_trans_saved">已保存，等待 SystemUI 确认</string>
     <string name="sub_trans_saved_pending">已保存，但 SystemUI 未确认应用，请检查模块是否已启用</string>

--- a/app/src/test/java/io/github/andrealtb/lockscreenlyrics/PlayerTranslationSettingsTest.java
+++ b/app/src/test/java/io/github/andrealtb/lockscreenlyrics/PlayerTranslationSettingsTest.java
@@ -33,14 +33,27 @@ public final class PlayerTranslationSettingsTest {
     }
 
     @Test
-    public void providerBackedPlayersExposeEightUniqueProviderPackages() {
+    public void providerBackedPlayersExposeNineUniqueProviderPackages() {
         String[] packages = PlayerTranslationSettings.providerPackages();
         HashSet<String> unique = new HashSet<>();
-        assertEquals(8, packages.length);
+        assertEquals(9, packages.length);
         for (String packageName : packages) {
             assertTrue(unique.add(packageName));
         }
         assertTrue(unique.contains("io.github.proify.lyricon.cmprovider"));
         assertTrue(unique.contains("io.github.proify.lyricon.qishuiprovider"));
+        assertTrue(unique.contains("io.github.proify.lyricon.metrolistprovider"));
+    }
+
+    @Test
+    public void translationSourceDrivesSupportedSwitches() {
+        for (PlayerTranslationSettings.Entry entry : PlayerTranslationSettings.entries()) {
+            if ("com.spotify.music".equals(entry.playerPackages[0])
+                    || "com.metrolist.music".equals(entry.playerPackages[0])) {
+                assertFalse(entry.supportsTranslation);
+            } else {
+                assertTrue(entry.supportsTranslation);
+            }
+        }
     }
 }

--- a/app/src/test/java/io/github/andrealtb/lockscreenlyrics/PlayerTranslationTogglePolicyTest.java
+++ b/app/src/test/java/io/github/andrealtb/lockscreenlyrics/PlayerTranslationTogglePolicyTest.java
@@ -1,0 +1,68 @@
+package io.github.andrealtb.lockscreenlyrics;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import java.util.Collections;
+import java.util.HashSet;
+
+import org.junit.Test;
+
+public class PlayerTranslationTogglePolicyTest {
+
+    @Test
+    public void registeredProvidersMayOverrideFavoriteActionWithTranslation() {
+        assertTrue(PlayerTranslationTogglePolicy.canOverrideFavoriteActionWithTranslation(
+                ExternalLyricProviderRegistry.QQ_MUSIC_PLAYER_PACKAGE,
+                Collections.emptySet()));
+        assertTrue(PlayerTranslationTogglePolicy.canOverrideFavoriteActionWithTranslation(
+                ExternalLyricProviderRegistry.KUGOU_MUSIC_PLAYER_PACKAGE,
+                Collections.emptySet()));
+        assertTrue(PlayerTranslationTogglePolicy.canOverrideFavoriteActionWithTranslation(
+                ExternalLyricProviderRegistry.NETEASE_MUSIC_PLAYER_PACKAGE,
+                Collections.emptySet()));
+    }
+
+    @Test
+    public void unknownPackagesCannotOverrideWithoutDeclaredCapability() {
+        assertFalse(PlayerTranslationTogglePolicy.canOverrideFavoriteActionWithTranslation(
+                "com.example.unknown",
+                Collections.emptySet()));
+        assertFalse(PlayerTranslationTogglePolicy.canOverrideFavoriteActionWithTranslation(
+                "",
+                Collections.emptySet()));
+        assertFalse(PlayerTranslationTogglePolicy.canOverrideFavoriteActionWithTranslation(
+                null,
+                Collections.emptySet()));
+    }
+
+    @Test
+    public void declaredCapabilityEnablesOverrideEvenWithoutRegistryEntry() {
+        HashSet<String> declared = new HashSet<>();
+        declared.add("com.example.player");
+        assertTrue(PlayerTranslationTogglePolicy.canOverrideFavoriteActionWithTranslation(
+                "com.example.player",
+                declared));
+    }
+
+    @Test
+    public void overrideRequiresCurrentProviderAndTranslationContent() {
+        String timedTranslation = "[00:01.00]翻译";
+        assertFalse(PlayerTranslationTogglePolicy.shouldReplaceFavoriteActionWithTranslation(
+                true, false, 3, timedTranslation));
+        assertFalse(PlayerTranslationTogglePolicy.shouldReplaceFavoriteActionWithTranslation(
+                false, true, 3, timedTranslation));
+        assertFalse(PlayerTranslationTogglePolicy.shouldReplaceFavoriteActionWithTranslation(
+                true, true, 0, "无时间戳的文本"));
+        assertFalse(PlayerTranslationTogglePolicy.shouldReplaceFavoriteActionWithTranslation(
+                true, true, 0, null));
+    }
+
+    @Test
+    public void translationsFromModelOrPayloadEnableTheOverride() {
+        assertTrue(PlayerTranslationTogglePolicy.shouldReplaceFavoriteActionWithTranslation(
+                true, true, 47, null));
+        assertTrue(PlayerTranslationTogglePolicy.shouldReplaceFavoriteActionWithTranslation(
+                true, true, 0, "[00:01.00]翻译行"));
+    }
+}

--- a/app/src/test/java/io/github/andrealtb/lockscreenlyrics/TranslationToggleMediaActionBinderTest.java
+++ b/app/src/test/java/io/github/andrealtb/lockscreenlyrics/TranslationToggleMediaActionBinderTest.java
@@ -1,0 +1,178 @@
+package io.github.andrealtb.lockscreenlyrics;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertSame;
+
+import android.content.Context;
+import android.graphics.drawable.Drawable;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import org.junit.Test;
+
+/**
+ * Stub-based tests for the media-card model operations. The binder reaches the stubs through the
+ * same name-based reflection it uses against SystemUI, so the fake classes intentionally mirror
+ * OplusMediaButtonEx / MediaAction method names.
+ *
+ * <p>The PlaybackState.CustomAction-mapped branch needs a real CustomAction instance and is
+ * covered by device validation; the fallback locator added for QQ Music / KuGou (original) is
+ * fully covered here.</p>
+ */
+public class TranslationToggleMediaActionBinderTest {
+
+    public static final class FakeMediaAction {
+        Runnable action;
+        CharSequence contentDescription;
+
+        public Runnable getAction() {
+            return action;
+        }
+
+        public void setAction(Runnable action) {
+            this.action = action;
+        }
+
+        public void setContentDescription(CharSequence value) {
+            this.contentDescription = value;
+        }
+
+        public Object getIcon() {
+            return null;
+        }
+    }
+
+    public static final class FakeMediaButtonEx {
+        final List<Object> rule0CustomActions = new ArrayList<>();
+        Object heartAction;
+
+        public List<Object> getRule0CustomActions() {
+            return rule0CustomActions;
+        }
+
+        public void setRule0CustomActions(List<?> actions) {
+            rule0CustomActions.clear();
+            rule0CustomActions.addAll(actions);
+        }
+
+        public Object getHeartAction() {
+            return heartAction;
+        }
+    }
+
+    public static final class FakeMediaButton {
+        final FakeMediaButtonEx ex = new FakeMediaButtonEx();
+
+        public FakeMediaButtonEx getMediaButtonEx() {
+            return ex;
+        }
+    }
+
+    private static final class FakeHost implements TranslationToggleMediaActionBinder.Host {
+        final Map<String, Boolean> translationEnabled = new HashMap<>();
+        int toggleClicks;
+
+        @Override
+        public Context currentApplicationContext() {
+            return null;
+        }
+
+        @Override
+        public String logProcessName() {
+            return "test";
+        }
+
+        @Override
+        public boolean isLyricInfoTranslationEnabled(String packageName) {
+            return translationEnabled.getOrDefault(packageName, Boolean.TRUE);
+        }
+
+        @Override
+        public void rememberTranslationIconFingerprint(Drawable drawable) {
+        }
+
+        @Override
+        public void onTranslationToggleClicked(String packageName) {
+            toggleClicks++;
+        }
+    }
+
+    private static TranslationToggleMediaActionBinder binder(FakeHost host) {
+        return new TranslationToggleMediaActionBinder(host);
+    }
+
+    @Test
+    public void singleActionFallbackBindsTranslationToggleClick() {
+        FakeMediaButton button = new FakeMediaButton();
+        FakeMediaAction action = new FakeMediaAction();
+        button.ex.rule0CustomActions.add(action);
+        FakeHost host = new FakeHost();
+
+        binder(host).applyTranslationToggle(
+                "com.example.player", button, true, true, "com.example.player", 5, 120);
+
+        assertNotNull(action.action);
+        action.action.run();
+        assertEquals(1, host.toggleClicks);
+        assertEquals("翻译：开启", action.contentDescription.toString());
+    }
+
+    @Test
+    public void heartMarkerFallbackPromotesFavoriteAction() {
+        FakeMediaButton button = new FakeMediaButton();
+        FakeMediaAction other = new FakeMediaAction();
+        FakeMediaAction heart = new FakeMediaAction();
+        button.ex.heartAction = heart;
+        button.ex.rule0CustomActions.add(other);
+        button.ex.rule0CustomActions.add(heart);
+        FakeHost host = new FakeHost();
+
+        binder(host).applyTranslationToggle(
+                "com.example.player", button, true, true, "com.example.player", 5, 120);
+
+        assertSame(heart, button.ex.rule0CustomActions.get(0));
+        assertNotNull(heart.action);
+        assertNull(other.action);
+    }
+
+    @Test
+    public void overrideSkippedWhenNotAllowedLeavesPlayerActionUntouched() {
+        FakeMediaButton button = new FakeMediaButton();
+        FakeMediaAction action = new FakeMediaAction();
+        button.ex.rule0CustomActions.add(action);
+        FakeHost host = new FakeHost();
+
+        binder(host).applyTranslationToggle(
+                "com.example.player", button, false, true, "com.example.player", 5, 120);
+
+        assertNull(action.action);
+        assertEquals(0, host.toggleClicks);
+    }
+
+    @Test
+    public void emptyActionListLeavesEverythingUntouched() {
+        FakeMediaButton button = new FakeMediaButton();
+        FakeHost host = new FakeHost();
+
+        binder(host).applyTranslationToggle(
+                "com.example.player", button, true, true, "com.example.player", 5, 120);
+
+        assertEquals(0, host.toggleClicks);
+    }
+
+    @Test
+    public void missingRule0ActionsAreSkippedQuietly() {
+        FakeHost host = new FakeHost();
+        Object mediaButton = new Object();
+
+        binder(host).applyTranslationToggle(
+                "com.example.player", mediaButton, true, true, "com.example.player", 5, 120);
+
+        assertEquals(0, host.toggleClicks);
+    }
+}

--- a/docs/TRANSLATION_TOGGLE_INTEGRATION.md
+++ b/docs/TRANSLATION_TOGGLE_INTEGRATION.md
@@ -1,0 +1,58 @@
+# 播放器翻译按钮接入约定（Translation Toggle Integration）
+
+锁屏/通知媒体卡固定 5 个槽位（收藏、上一首、暂停/播放、下一首、扬声器切换），因此翻译开关按钮
+**不能新增，只能替换该播放器的“收藏”按钮**。本文定义接入该能力的约定，供后续新适配播放器复用。
+
+## 1. 代码分层
+
+- PlayerTranslationTogglePolicy：纯决策（能否替换、是否需要替换），不接触 SystemUI 对象。
+- TranslationToggleMediaActionBinder：媒体卡模型操作（定位收藏、原地替换、提升、图标/文案呈现、
+  点击绑定），不决策。
+- LockscreenLyricsModule：只保留 Hook 入口与运行时状态（翻译显隐记忆、按钮偏好、视图追踪）。
+
+## 2. 收藏定位顺序（SystemUI 侧）
+
+替换动作前先定位该播放器的收藏按钮：
+
+1. PlaybackState.CustomAction 映射（网易云/Apple/汽水/酷狗 Lite 等走此路）；
+2. OPlus heart 标记（OplusMediaButtonEx#getHeartAction / MediaActionEx#hasHeartFromRating）；
+3. Rule0 自定义动作列表唯一动作兜底（QQ 音乐、原版酷狗实测走此路，其收藏不携带
+   PlaybackState.CustomAction）。
+
+定位失败或当前曲目无翻译内容时不替换；替换仅发生在“用户开启该播放器的媒体卡翻译按钮”且
+“该播放器是当前歌词 Provider”且“当前曲目有翻译”三者同时成立时。
+
+## 3. Provider 接入要求
+
+- 能提供翻译的播放器：在 v4 直达广播中声明 translationToggle 能力，并持续发送合法的
+  translationLyric（带时间戳的 LRC）。
+- 拿不到翻译的播放器（Spotify、Metrolist）：不得声明 translationToggle。
+- 外部 Provider 不需要任何注入逻辑；按钮由 SystemUI 侧替换收藏槽位实现。
+- 内置适配器（Salt、Cone 等）：调用 installInjectedTranslationToggleActionHook 走公开按钮
+  （public）路径，收藏槽位不受影响。
+
+## 4. 设置项
+
+- “默认显示翻译”与“清除翻译记忆”：控制翻译行显隐（显示链路，独立于按钮）。
+- “锁屏媒体卡翻译按钮”（默认开）：开 = 收藏槽位换成翻译开关；关 = 恢复播放器自带收藏。
+  存储键 lyric_info_translation_button.<playerPackage>，随
+  ACTION_PLAYER_TRANSLATION_SETTINGS_CHANGED 广播以
+  EXTRA_TRANSLATION_BUTTON_PACKAGES / EXTRA_TRANSLATION_BUTTON_VALUES 传输。
+- 无翻译源播放器（Spotify、Metrolist）：卡片保留用于检测 Provider 安装状态，显示
+  “不支持翻译”，不显示任何开关。
+
+## 4.1 已知特殊案例：Apple Music
+
+Apple Music 的收藏是评分式槽位（MediaMetadata USER_RATING/RATING），其渲染图标来自媒体卡
+模型之外的来源：模型层图标替换确认生效（MediaAction.icon 与 mediaActionEx.icon 均已写入），
+但界面仍渲染播放器自带图标，静态替换不可达。定版决策：图标保留 AM 自带（与翻译功能匹配），
+不再强制替换；按钮功能与其余行为正常。
+
+## 5. 调试与验证
+
+- 按钮诊断日志只在 debug 构建存在（TRANSLATION_BUTTON_DIAGNOSTICS_ENABLED = BuildConfig.DEBUG），
+  必须安装 assembleDebug 产物并抓 LockscreenLyrics Tag。
+- 关键日志行：inspect Rule0 actions、override fallback located ...、configure translation
+  action、Configured lyricInfo translation toggle、no translation action candidate。
+- 真机验证矩阵：开关开 → 收藏槽位变为翻译按钮（日志确认替换的是收藏而非扬声器切换）、点击切换
+  翻译行、重启保持；开关关 → 收藏恢复、无翻译按钮；扬声器切换全程不受影响。

--- a/docs/releases/v3.7.2.md
+++ b/docs/releases/v3.7.2.md
@@ -1,0 +1,9 @@
+# ColorOS Live Lyrics Bridge v3.7.2
+
+v3.7.2 重构“播放器翻译设置”：翻译开关按钮统一占用锁屏媒体卡收藏槽位（媒体卡固定 5 个按钮，
+只能替换、不能新增），并为 QQ 音乐、原版酷狗修复此前失效的翻译按钮；新增分播放器
+“锁屏媒体卡翻译按钮”开关；设置页建立播放器卡片接入约定（按是否有翻译源显示开关），
+Spotify/Metrolist 明确显示“不支持翻译”。外部歌词 v4 协议、Provider 准入规则与既有
+AOD/渲染行为保持兼容，本次无 Provider 变更。
+
+完整发布说明见 [Bridge `.github/release-notes/3.7.2.md`](../../.github/release-notes/3.7.2.md)。


### PR DESCRIPTION
# ColorOS Live Lyrics Bridge v3.7.2

v3.7.2 重构“播放器翻译设置”：翻译开关按钮统一占用锁屏媒体卡收藏槽位（媒体卡固定 5 个按钮，
只能替换、不能新增），并为 QQ 音乐、原版酷狗修复此前失效的翻译按钮；新增分播放器
“锁屏媒体卡翻译按钮”开关；设置页建立播放器卡片接入约定（按是否有翻译源显示开关），
Spotify/Metrolist 明确显示“不支持翻译”。外部歌词 v4 协议、Provider 准入规则与既有
AOD/渲染行为保持兼容，本次无 Provider 变更。

## 播放器翻译设置重构

- 代码分层：新增 `PlayerTranslationTogglePolicy`（纯决策）与
  `TranslationToggleMediaActionBinder`（媒体卡模型操作：定位收藏、原地替换、提升、呈现、
  点击绑定），`LockscreenLyricsModule` 不再承载媒体动作操作，只保留 Hook 入口与运行时状态。
- 收藏定位三级兜底：`PlaybackState.CustomAction` 映射 → OPlus heart 标记
  （`getHeartAction` / `hasHeartFromRating`）→ Rule0 列表唯一动作。QQ 音乐、原版酷狗的收藏
  不携带 CustomAction（设备日志确认），此前翻译按钮完全失效，现经兜底恢复可用。
- 分播放器“锁屏媒体卡翻译按钮”开关（默认开）：开 = 收藏槽位换成翻译开关；关 = 恢复播放器
  自带收藏。开关覆盖三条按钮路径：替换收藏（QQ/酷狗/网易云/Apple/汽水/酷狗 Lite）、公开注入
  按钮（LX/Poweramp/Cone 等，关闭时从媒体卡移除）、Salt 自带桌面歌词按钮（关闭时恢复播放器
  自身行为）。
- 图标加载修复：模块 `ic_translation` 改为从资源所属包 Context 直接加载；此前
  `Icon.loadDrawable` 在 SystemUI 侧对跨包资源静默返回 null，导致按钮图标未被替换。
- 无翻译歌曲恢复播放器自带收藏：修复媒体卡按钮视图回收复用导致“只剩 4 个按钮”的问题，
  媒体卡始终 5 个按钮。

## 设置页卡片接入约定

- 播放器卡片新增 `supportsTranslation` 声明：有翻译源的播放器显示“默认显示翻译 / 锁屏媒体卡
  翻译按钮 / 清除记忆”；无翻译源的播放器（Spotify、Metrolist）保留卡片用于检测
  LyricProvider 安装状态，显示“不支持翻译”且不显示任何开关。
- 新增 Metrolist 卡片，并修复其 Provider 检测（manifest `<queries>` 补充
  `io.github.proify.lyricon.metrolistprovider`，此前 Android 11+ 包可见性导致卡片误灰置）。
- 新播放器接入约定见 `docs/TRANSLATION_TOGGLE_INTEGRATION.md`。

## 已知特殊案例

- Apple Music：收藏采用评分式槽位，其渲染图标来自媒体卡模型之外的来源，静态替换不可达；
  翻译按钮图标保留播放器自带（与翻译功能匹配），按钮功能与其余行为正常。

## LyricProvider

- 本次无 Provider 功能变更；全部 Provider APK 仍随 Release 附带，供按需更新。

## 兼容与验证

- 外部歌词协议仍为 v4；现有 Provider 的 source / playerPackage / senderPackage /
  senderKind 静态白名单校验不变。
- 未修改官方 Renderer 的 AOD 切换时序、`LyricsRecyclerView` prime 或普通 `TextView`
  Hook 范围。
- `scripts\dev.cmd bridge testDebugUnitTest assembleDebug` 通过（423 项测试 0 失败）。
- 真机验证（OPPO 设备，debug 构建）：
  - QQ 音乐、原版酷狗：收藏槽位变为翻译按钮、点击切换翻译行、开关关恢复收藏 —— 通过；
  - Salt/Cone/LX/Poweramp/汽水：媒体卡翻译按钮开关开/关全部生效，Salt 图标修复为模块
    翻译图标 —— 通过；
  - 无翻译歌曲恢复播放器自带收藏、媒体卡保持 5 个按钮 —— 通过；
  - Metrolist 卡片亮起并显示“不支持翻译”、无开关 —— 通过；
  - Apple Music 图标为播放器自带（特殊案例，见上）。

## 升级说明

- 更新 Bridge 为 `ColorOS-Live-Lyrics-Bridge-v3.7.2.apk`；本次无 Provider 变更，无需更新
  Provider。
- 更新后重启对应播放器进程；如 LSPosed 仍加载旧模块，请重启设备。
- “播放器翻译设置”新增的“锁屏媒体卡翻译按钮”默认开启；不希望收藏槽位被替换的用户可
  逐播放器关闭。

## Release 资产

- `ColorOS-Live-Lyrics-Bridge-v3.7.2.apk`
- `LyricProvider-QQMusic-v3.7.2.apk`
- `LyricProvider-163Music-v3.7.2.apk`
- `LyricProvider-AppleMusic-v3.7.2.apk`
- `LyricProvider-Poweramp-v3.7.2.apk`
- `LyricProvider-Spotify-v3.7.2.apk`
- `LyricProvider-QiShui-v3.7.2.apk`
- `LyricProvider-KuGou-v3.7.2.apk`
- `LyricProvider-LXMusic-v3.7.2.apk`
- `LyricProvider-Metrolist-v3.7.2.apk`
- `LyricProvider-v3.7.2.zip`

Provider 为独立 LSPosed 模块，只需安装自己使用的播放器对应 APK。
