### PR TITLE
适配 Salt Player 12.2.1

### DIFF
--- a/app/src/main/java/io/github/andrealtb/lockscreenlyrics/SaltPlayerAdapter.java
+++ b/app/src/main/java/io/github/andrealtb/lockscreenlyrics/SaltPlayerAdapter.java
@@ -310,7 +310,8 @@ final class SaltPlayerAdapter implements PlayerAdapter {
                         chain,
                         lyricResultClass,
                         sourceEnumClass));
-        module.info("Using Salt Player final lyric publisher: " + publisher.getName());
+        module.info("Using Salt Player final lyric publisher: "
+                + publisher.getName() + "#" + invokeSuspend.getName());
     }
 
     private static ClassData findFinalLyricPublisherClass(
@@ -335,8 +336,35 @@ final class SaltPlayerAdapter implements PlayerAdapter {
                         + ": " + classes);
     }
 
-    private static Method findInvokeSuspendMethod(Class<?> publisherClass)
+    static Method findInvokeSuspendMethod(Class<?> publisherClass)
             throws NoSuchMethodException {
+        Method named = findNamedInvokeSuspend(publisherClass);
+        if (named != null) {
+            return named;
+        }
+        // Salt 12.2.1 obfuscates coroutine method names (invoke/create/invokeSuspend) with a
+        // non-printable CJK dictionary. Fall back to the unique structural signature of the
+        // suspended publisher body: exactly one java.lang.Object parameter. Fail loudly when
+        // the shape is ambiguous instead of hooking an unrelated method.
+        Method structural = null;
+        for (Method method : publisherClass.getDeclaredMethods()) {
+            Class<?>[] parameterTypes = method.getParameterTypes();
+            if (parameterTypes.length == 1 && parameterTypes[0] == Object.class) {
+                if (structural != null) {
+                    throw new NoSuchMethodException(
+                            "Ambiguous Salt Player publisher method candidates: "
+                                    + structural + " vs " + method);
+                }
+                structural = method;
+            }
+        }
+        if (structural != null) {
+            return structural;
+        }
+        throw new NoSuchMethodException(publisherClass.getName() + "#invokeSuspend(Object)");
+    }
+
+    static Method findNamedInvokeSuspend(Class<?> publisherClass) {
         for (Method method : publisherClass.getDeclaredMethods()) {
             Class<?>[] parameterTypes = method.getParameterTypes();
             if ("invokeSuspend".equals(method.getName())
@@ -345,7 +373,7 @@ final class SaltPlayerAdapter implements PlayerAdapter {
                 return method;
             }
         }
-        throw new NoSuchMethodException(publisherClass.getName() + "#invokeSuspend(Object)");
+        return null;
     }
 
     private static Object onFinalLyricPublication(

--- a/app/src/test/java/io/github/andrealtb/lockscreenlyrics/SaltPlayerAdapterMethodResolutionTest.java
+++ b/app/src/test/java/io/github/andrealtb/lockscreenlyrics/SaltPlayerAdapterMethodResolutionTest.java
@@ -1,0 +1,87 @@
+package io.github.andrealtb.lockscreenlyrics;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThrows;
+import static org.junit.Assert.assertTrue;
+
+import java.lang.reflect.Method;
+
+import org.junit.Test;
+
+/**
+ * Covers Salt Player final-publisher coroutine method resolution. Salt 12.2.1 obfuscates
+ * coroutine method names (invoke/create/invokeSuspend) with a non-printable CJK dictionary, so
+ * resolution must fall back to the unique single-Object-parameter structural signature.
+ */
+public final class SaltPlayerAdapterMethodResolutionTest {
+
+    @Test
+    public void prefersLiteralInvokeSuspendName() throws Exception {
+        Method method = SaltPlayerAdapter.findInvokeSuspendMethod(NamedPublisher.class);
+
+        assertEquals("invokeSuspend", method.getName());
+        assertEquals(1, method.getParameterTypes().length);
+        assertEquals(Object.class, method.getParameterTypes()[0]);
+    }
+
+    @Test
+    public void fallsBackToUniqueSingleObjectParameterMethod() throws Exception {
+        Method method = SaltPlayerAdapter.findInvokeSuspendMethod(ObfuscatedPublisher.class);
+
+        assertEquals("mo135", method.getName());
+        assertEquals(1, method.getParameterTypes().length);
+        assertEquals(Object.class, method.getParameterTypes()[0]);
+    }
+
+    @Test
+    public void rejectsPublisherWithoutSuspendShape() {
+        assertThrows(
+                NoSuchMethodException.class,
+                () -> SaltPlayerAdapter.findInvokeSuspendMethod(NoCandidatePublisher.class));
+    }
+
+    @Test
+    public void rejectsAmbiguousStructuralCandidates() {
+        NoSuchMethodException error = assertThrows(
+                NoSuchMethodException.class,
+                () -> SaltPlayerAdapter.findInvokeSuspendMethod(AmbiguousPublisher.class));
+
+        assertTrue(error.getMessage().contains("Ambiguous"));
+    }
+
+    private static final class NamedPublisher {
+        public Object invoke(Object a, Object b) {
+            return null;
+        }
+
+        public Object invokeSuspend(Object o) {
+            return null;
+        }
+    }
+
+    private static final class ObfuscatedPublisher {
+        public Object mo321(Object a, Object b) {
+            return null;
+        }
+
+        public Object mo135(Object o) {
+            return null;
+        }
+    }
+
+    private static final class NoCandidatePublisher {
+        public Object invoke(Object a, Object b) {
+            return null;
+        }
+    }
+
+    private static final class AmbiguousPublisher {
+        public Object first(Object o) {
+            return null;
+        }
+
+        public Object second(Object o) {
+            return null;
+        }
+    }
+}


### PR DESCRIPTION
Salt 12.2.1 的 R8 用 CJK 字典重命名了协程状态机方法（invoke/create/invokeSuspend），发布协程中歌词发布方法不再叫 invokeSuspend，导致 DexKit 按字面名查找失败、歌词 Hook 失效。

- findInvokeSuspendMethod 保留字面名优先（旧版 Salt 行为不变），未命中时回退到唯一单 Object 参数的结构签名（12.2.1 的 ju1#庄），歧义时显式报错。
- 发布日志附带实际方法名便于后续版本对照。
- 新增 SaltPlayerAdapterMethodResolutionTest 4 项单测；testDebugUnitTest + assembleDebug 通过。
- 真机日志（Salt 12.2.1）：Hook 安装成功，SALT_FINAL_EMBEDDED 歌词正常接收。
