### PR TITLE
Admit Halcyon as a native v4 lyric provider

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,14 +59,15 @@ There are two ways a player can work with the module:
 | Spotify | `LyricProvider-Spotify` | Direct v4 provider admitted by the Bridge; standard original lyrics only; translations are not currently supported |
 | QiShui Music | `LyricProvider-QiShui` | Direct v4 provider admitted by the Bridge; word-timed and translated lyrics; proper root hiding and the special setup below are required |
 | KuGou Music / Concept | `LyricProvider-KuGou` | Direct v4 provider admitted by the Bridge; word-timed and translated lyrics |
+| [Halcyon](https://github.com/Kifranei/Halcyon) | No | Native `lyricInfo` plus in-app direct v4 (`lyricprovider/halcyon`); word-timed and translated lyrics |
 
 [Metrolist](https://github.com/metrolistgroup/metrolist) is a **YouTube Music client for Android**. Because Metrolist itself does not provide a stable lyric retrieval interface, this Provider retrieves lyrics from third-party lyric providers in the same way as Metrolist. The lyrics selected by the Provider may therefore differ from those shown inside Metrolist.
 
-The Provider list above follows the Bridge's direct v4 admission registry: a Provider is considered adapted when its source and player package are admitted by the Bridge. The current admitted Provider sources are `qq-music`, `netease-cloud-music`, `apple-music`, `lx-music`, `lx-walnut-music`, `poweramp-music`, `spotify-music`, `qishui-music`, `kugou-music`, `kugou-concept-music`, and `metrolist-music`. Other modules present in the LyricProvider repository are not included in this adapted list unless their source and host package are added to the Bridge registry.
+The Provider list above follows the Bridge's direct v4 admission registry: a Provider is considered adapted when its source and player package are admitted by the Bridge. The current admitted Provider sources are `qq-music`, `netease-cloud-music`, `apple-music`, `lx-music`, `lx-walnut-music`, `poweramp-music`, `spotify-music`, `qishui-music`, `kugou-music`, `kugou-concept-music`, `metrolist-music`, and `halcyon`. Other modules present in the LyricProvider repository are not included in this adapted list unless their source and host package are added to the Bridge registry.
 
 Music apps can change their private lyric interfaces at any time. This table describes the adapters present in the current code; it is not a promise that every future player release will remain compatible.
 
-Players that publish the public `lyricInfo` protocol usually need neither a dedicated Provider nor Bridge scope in the player process. [Halcyon](https://github.com/Kifranei/Halcyon) is one known native integration.
+Players that publish the public `lyricInfo` protocol usually need neither a dedicated Provider nor Bridge scope in the player process. [Halcyon](https://github.com/Kifranei/Halcyon) is a known native integration and also sends direct v4 Provider broadcasts (`lyricprovider/halcyon` from `com.ella.music`) so ColorOS 16.9+ can still receive lyrics after extras-only `lyricInfo` updates are dropped. No extra Provider APK is required.
 
 ## Installation
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -59,14 +59,15 @@
 | Spotify | `LyricProvider-Spotify` | Bridge 已放行 v4 直达 Provider；目前只支持原文标准歌词，不支持翻译 |
 | 汽水音乐 | `LyricProvider-QiShui` | Bridge 已放行 v4 直达 Provider；支持逐字歌词、翻译歌词；需做好 Root 隐藏并完成下方特殊设置 |
 | 酷狗音乐 / 酷狗概念版 | `LyricProvider-KuGou` | Bridge 已放行 v4 直达 Provider；支持逐字歌词、翻译歌词 |
+| [Halcyon](https://github.com/Kifranei/Halcyon) | 否 | 主动 `lyricInfo` + 应用内 v4 广播（`lyricprovider/halcyon`）；支持逐字与翻译 |
 
 [Metrolist](https://github.com/metrolistgroup/metrolist) 是**适用于安卓系统的 YouTube Music 客户端**。由于 Metrolist 本身没有稳定的歌词获取接口，本 Provider 采用与 Metrolist 相同的方式从第三方歌词提供商获取歌词，因此两者获取的歌词可能存在差异。
 
-上表以 Bridge 的 v4 直达放行注册表为准：Provider 的 `source` 与播放器包名已被 Bridge 静态放行，即视为已完成 Bridge 适配。目前放行的 Provider source 为：`qq-music`、`netease-cloud-music`、`apple-music`、`lx-music`、`lx-walnut-music`、`poweramp-music`、`spotify-music`、`qishui-music`、`kugou-music`、`kugou-concept-music` 和 `metrolist-music`。LyricProvider 仓库中其他模块虽然存在，但在加入 Bridge 注册表前不属于当前适配清单。
+上表以 Bridge 的 v4 直达放行注册表为准：Provider 的 `source` 与播放器包名已被 Bridge 静态放行，即视为已完成 Bridge 适配。目前放行的 Provider source 为：`qq-music`、`netease-cloud-music`、`apple-music`、`lx-music`、`lx-walnut-music`、`poweramp-music`、`spotify-music`、`qishui-music`、`kugou-music`、`kugou-concept-music`、`metrolist-music` 和 `halcyon`。LyricProvider 仓库中其他模块虽然存在，但在加入 Bridge 注册表前不属于当前适配清单。
 
 播放器更新后，私有歌词接口可能发生变化。表格表示当前代码已经包含相应适配，不代表未来所有播放器版本都能永久兼容。
 
-已经主动支持公开 `lyricInfo` 协议的播放器通常不需要额外 Provider，也不需要加入 Bridge 的播放器作用域。当前已知主动接入项目包括 [Halcyon](https://github.com/Kifranei/Halcyon)。
+已经主动支持公开 `lyricInfo` 协议的播放器通常不需要额外 Provider，也不需要加入 Bridge 的播放器作用域。[Halcyon](https://github.com/Kifranei/Halcyon) 会同时发布 `lyricInfo` 并从播放器进程发送 v4 Provider 广播（`lyricprovider/halcyon` / `com.ella.music`），以便 ColorOS 16.9 起 extras-only 更新被丢弃后仍能收到歌词，无需额外 Provider APK。
 
 ## 安装
 

--- a/app/src/main/java/io/github/andrealtb/lockscreenlyrics/ExternalLyricProviderRegistry.java
+++ b/app/src/main/java/io/github/andrealtb/lockscreenlyrics/ExternalLyricProviderRegistry.java
@@ -31,6 +31,8 @@ final class ExternalLyricProviderRegistry {
     static final String LX_WALNUT_MUSIC_SOURCE = "lyricprovider/lx-walnut-music";
     static final String METROLIST_PLAYER_PACKAGE = "com.metrolist.music";
     static final String METROLIST_SOURCE = "lyricprovider/metrolist-music";
+    static final String HALCYON_PLAYER_PACKAGE = "com.ella.music";
+    static final String HALCYON_SOURCE = "lyricprovider/halcyon";
 
     private static final Source[] EXTERNAL_SOURCES = {
             new Source(APPLE_MUSIC_SOURCE, APPLE_MUSIC_PLAYER_PACKAGE, false, false, false),
@@ -50,7 +52,11 @@ final class ExternalLyricProviderRegistry {
                     true,
                     false),
             new Source(POWERAMP_SOURCE, POWERAMP_PLAYER_PACKAGE, false, true, true),
-            new Source(METROLIST_SOURCE, METROLIST_PLAYER_PACKAGE, true, true, false)
+            new Source(METROLIST_SOURCE, METROLIST_PLAYER_PACKAGE, true, true, false),
+            // Native player: Halcyon sends v4 from its own process after ColorOS 16.9
+            // started dropping extras-only lyricInfo. Keep MediaSession as the
+            // playback clock; allow title-only fallback for local files.
+            new Source(HALCYON_SOURCE, HALCYON_PLAYER_PACKAGE, false, true, true)
     };
 
     private static final String[] BRIDGE_PLAYER_PACKAGES = {
@@ -66,7 +72,8 @@ final class ExternalLyricProviderRegistry {
             QISHUI_MUSIC_PLAYER_PACKAGE,
             KUGOU_MUSIC_PLAYER_PACKAGE,
             KUGOU_CONCEPT_MUSIC_PLAYER_PACKAGE,
-            METROLIST_PLAYER_PACKAGE
+            METROLIST_PLAYER_PACKAGE,
+            HALCYON_PLAYER_PACKAGE
     };
 
     private ExternalLyricProviderRegistry() {
@@ -139,7 +146,8 @@ final class ExternalLyricProviderRegistry {
                 || QISHUI_MUSIC_PLAYER_PACKAGE.equals(packageName)
                 || KUGOU_MUSIC_PLAYER_PACKAGE.equals(packageName)
                 || KUGOU_CONCEPT_MUSIC_PLAYER_PACKAGE.equals(packageName)
-                || METROLIST_PLAYER_PACKAGE.equals(packageName);
+                || METROLIST_PLAYER_PACKAGE.equals(packageName)
+                || HALCYON_PLAYER_PACKAGE.equals(packageName);
     }
 
     private static Source findBySource(String source) {

--- a/app/src/test/java/io/github/andrealtb/lockscreenlyrics/ExternalLyricProviderRegistryTest.java
+++ b/app/src/test/java/io/github/andrealtb/lockscreenlyrics/ExternalLyricProviderRegistryTest.java
@@ -30,6 +30,9 @@ public class ExternalLyricProviderRegistryTest {
         assertEquals("com.metrolist.music",
                 ExternalLyricProviderRegistry.trustedHostPackageForSource(
                         "lyricprovider/metrolist-music"));
+        assertEquals("com.ella.music",
+                ExternalLyricProviderRegistry.trustedHostPackageForSource(
+                        "lyricprovider/halcyon"));
         assertEquals("", ExternalLyricProviderRegistry.trustedHostPackageForSource("unknown"));
     }
 
@@ -49,6 +52,8 @@ public class ExternalLyricProviderRegistryTest {
                 "lyricprovider/lx-walnut-music", "com.lxwalnut.music.mobile"));
         assertTrue(ExternalLyricProviderRegistry.isTrustedSourceBoundToHostPackage(
                 "lyricprovider/metrolist-music", "com.metrolist.music"));
+        assertTrue(ExternalLyricProviderRegistry.isTrustedSourceBoundToHostPackage(
+                "lyricprovider/halcyon", "com.ella.music"));
         assertFalse(ExternalLyricProviderRegistry.isTrustedSourceBoundToHostPackage(
                 "lyricprovider/spotify-music", "com.tencent.qqmusic"));
         assertFalse(ExternalLyricProviderRegistry.isTrustedSourceBoundToHostPackage(
@@ -90,6 +95,13 @@ public class ExternalLyricProviderRegistryTest {
         assertTrue(metrolist.supportsTrackGeneration);
         assertTrue(metrolist.canPromoteAsAuthoritative);
         assertFalse(metrolist.allowsTitleOnlyFallbackMatch);
+
+        ExternalLyricSourceProfile halcyon =
+                ExternalLyricSourceProfile.registeredProviderDefaults(
+                        "lyricprovider/halcyon");
+        assertTrue(halcyon.canPromoteAsAuthoritative);
+        assertTrue(halcyon.allowsTitleOnlyFallbackMatch);
+        assertFalse(halcyon.supportsPlaybackState);
     }
 
     @Test

--- a/docs/LYRIC_PROVIDER_BRIDGE.zh-CN.md
+++ b/docs/LYRIC_PROVIDER_BRIDGE.zh-CN.md
@@ -25,6 +25,7 @@ Bridge 侧的 Provider/播放器信息集中在 `ExternalLyricSources`：
 | 汽水音乐 | `com.luna.music` | bridge 播放器包名、`lyricprovider/qishui-music` source、历史播放器/AOD 放行、外部播放状态、翻译开关 |
 | 酷狗音乐 | `com.kugou.android` | bridge 播放器包名、`lyricprovider/kugou-music` source、历史播放器/AOD 放行、外部播放状态、翻译开关 |
 | 酷狗音乐概念版 | `com.kugou.android.lite` | bridge 播放器包名、`lyricprovider/kugou-concept-music` source、历史播放器/AOD 放行、外部播放状态、翻译开关 |
+| Halcyon | `com.ella.music` | bridge 播放器包名、`lyricprovider/halcyon` source、历史播放器/AOD 放行、外部歌词提升、翻译开关；播放状态沿用原生 MediaSession |
 
 包名在 `BRIDGE_PLAYER_PACKAGES` 后，会自动进入 OPlus 历史播放器和 AOD 媒体面板放行逻辑。source 在 `EXTERNAL_SOURCES` 后，Bridge 才能把 Provider 广播反查到播放器包名，用于重试提升、无官方 `lyricInfo` 时的当前曲目绑定，以及可选的外部播放状态接收。
 


### PR DESCRIPTION
Halcyon (\com.ella.music\) already publishes public \lyricInfo\, but ColorOS 16.9+ drops extras-only MediaSession updates (\hasLyric=false\ until the next track). The player now also sends **direct v4** broadcasts from its own process:

- action: \EXTERNAL_LYRIC_DIRECT_V4\
- source: \lyricprovider/halcyon\
- playerPackage / senderPackage: \com.ella.music\
- senderKind: \provider\
- events: \	rackChanged\ then \lyricReady\
- no extra Provider APK, no Bridge \scope.list\ change

This PR only adds the static admission binding Bridge requires (\source\ to package, plus history/AOD package). Capabilities match Poweramp: native MediaSession is the playback clock (\supportsPlaybackState=false\), current-track authority and title-only fallback are on for local files.

Refs: https://github.com/Kifranei/Halcyon/issues/444