### PR TITLE
Support event-driven sentence windows for Readify TTS

### DIFF
--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -190,3 +190,7 @@ Copyright 2026 Andrea-lyz。本项目采用 [Apache License 2.0](LICENSE) 开源
 插件化歌词源方面提供的开源工作与启发。
 
 Android、ColorOS、OPlus、LSPosed 以及各音乐 App 名称的商标权归各自权利人所有。本项目与这些产品的官方团队没有隶属或背书关系。
+
+## Readify 句子窗口（提案）
+
+Readify 在线朗读适配及事件驱动高亮见 [协议与验证说明](docs/SENTENCE_WINDOWS.md)。需要配套 Provider；Bridge 的系统作用域不变。

--- a/app/src/main/java/io/github/andrealtb/lockscreenlyrics/LockscreenLyricsModule.java
+++ b/app/src/main/java/io/github/andrealtb/lockscreenlyrics/LockscreenLyricsModule.java
@@ -1827,7 +1827,8 @@ public final class LockscreenLyricsModule extends XposedModule {
 
     private void rebuildCurrentWordLyricModelForCleanup() {
         LyricInfoContract.Payload current = currentLyricProviderPayload;
-        if (current == null || TextUtils.isEmpty(currentCleanupSnapshotRawLyric)) return;
+        if (current == null || current.snapshotPositionMillis >= 0L
+                || TextUtils.isEmpty(currentCleanupSnapshotRawLyric)) return;
         try {
             JSONObject object = new JSONObject();
             object.put(LyricInfoContract.JSON_SONG_NAME, current.songName);
@@ -3270,7 +3271,9 @@ public final class LockscreenLyricsModule extends XposedModule {
             String fallbackArtist,
             boolean rememberSnapshot,
             LyricContentCleanupConfig cleanupConfig) {
-        if (normalized == null || normalized.payload == null) {
+        if (normalized == null || normalized.payload == null
+                || normalized.payload.snapshotPositionMillis >= 0L) {
+            // Event-driven row indices must survive content cleanup unchanged.
             return normalized;
         }
         try {
@@ -3348,6 +3351,10 @@ public final class LockscreenLyricsModule extends XposedModule {
             resetSystemUiPlaybackPositionForLyricTrackChange(payload);
         }
         currentLyricProviderPayload = payload;
+        if (payload.snapshotPositionMillis >= 0L) {
+            info(BridgeDebugArea.LYRIC, BridgeEvents.DETAIL,
+                    "Snapshot accepted; current=" + payload.snapshotPositionMillis / 1000L);
+        }
         currentLyricObservedTrackKey = buildTrackKey(observedTitle, observedArtist);
         if (isNativeV5Payload(payload) && !TextUtils.isEmpty(nextClockTrackKey)) {
             playbackClockTrackKey = nextClockTrackKey;
@@ -3440,7 +3447,18 @@ public final class LockscreenLyricsModule extends XposedModule {
         return powerManager != null && !powerManager.isInteractive();
     }
 
+    private int lyricTextLengthLimit() {
+        // 1600 Unicode code points plus normalization spaces and surrogate pairs.
+        return hasSentenceWindow() ? 4800 : 240;
+    }
+
+    private boolean hasSentenceWindow() {
+        LyricInfoContract.Payload payload = currentLyricProviderPayload;
+        return payload != null && payload.snapshotPositionMillis >= 0L;
+    }
+
     private boolean shouldModulePositionLyricsRecycler() {
+        if (hasSentenceWindow()) return true;
         return LyricsRecyclerPolicy.shouldModulePosition(
                 aodLowFrameRateLyricMode,
                 isScreenInteractiveForWakeLock(),
@@ -3448,6 +3466,7 @@ public final class LockscreenLyricsModule extends XposedModule {
     }
 
     private boolean systemUiOwnsNativeLyricsRecycler() {
+        if (hasSentenceWindow()) return false;
         LyricInfoContract.Payload payload = currentLyricProviderPayload;
         if (payload != null) {
             return isNativeV5Payload(payload);
@@ -5192,6 +5211,17 @@ public final class LockscreenLyricsModule extends XposedModule {
         }
         Object recycler = chain.getThisObject();
         View recyclerView = recycler instanceof View ? (View) recycler : null;
+        LyricInfoContract.Payload snapshot = currentLyricProviderPayload;
+        if (snapshot != null && snapshot.snapshotPositionMillis >= 0L
+                && isOfficialTimedCurrentLyricExecutable(chain.getExecutable())) {
+            Object[] args = chain.getArgs().toArray(new Object[0]);
+            args[1] = TimedLyricMethodPolicy.position(snapshot.snapshotPositionMillis, (Long) args[1]);
+            Object result = chain.proceed(args);
+            if (recyclerView != null) rememberLyricsRecyclerView(recyclerView);
+            info(BridgeDebugArea.RENDERER, BridgeEvents.DETAIL,
+                    "Pinned native lyric clock; current=" + snapshot.snapshotPositionMillis / 1000L);
+            return result;
+        }
         if (recyclerView != null) {
             rememberLyricsRecyclerView(recyclerView);
         }
@@ -5679,6 +5709,11 @@ public final class LockscreenLyricsModule extends XposedModule {
                 && lastPrimedLyricsRecyclerIndex == targetIndex
                 && hasBoundLyricsRecyclerChildren(recycler);
         boolean positioned = alreadyPrimed || invokeLyricsRecyclerSetCurrentLyric(recycler, targetIndex);
+        if (!positioned && hasSentenceWindow()) {
+            // Some firmware has no discoverable current-line method. Keep the same official
+            // RecyclerView geometry and use the existing layout-manager positioning fallback.
+            positioned = forceAlignLyricsRecyclerToIndex(recycler, targetIndex, "sentence-window");
+        }
         applyVisibleLyricBlockHeights(recycler);
         if (positioned && hasBoundLyricsRecyclerChildren(recycler)) {
             lastPrimedLyricsRecyclerView = new WeakReference<>(recycler);
@@ -6111,7 +6146,7 @@ public final class LockscreenLyricsModule extends XposedModule {
             CharSequence text = textView.getText();
             if (text != null
                     && text.length() > 0
-                    && text.length() <= 240
+                    && text.length() <= lyricTextLengthLimit()
                     && isInLyricsRecyclerView(textView)) {
                 LyricTextMatch match = findLyricTextMatch(
                         model,
@@ -6144,7 +6179,7 @@ public final class LockscreenLyricsModule extends XposedModule {
             return;
         }
         CharSequence text = textView.getText();
-        if (text == null || text.length() == 0 || text.length() > 240) {
+        if (text == null || text.length() == 0 || text.length() > lyricTextLengthLimit()) {
             return;
         }
         prebindOfficialLyricSlotAfterTextMutation(textView);
@@ -6357,7 +6392,7 @@ public final class LockscreenLyricsModule extends XposedModule {
             String normalizedText = text == null ? "" : normalizedTextOf(textView);
             if (text != null
                     && text.length() > 0
-                    && text.length() <= 240
+                    && text.length() <= lyricTextLengthLimit()
                     && model.hasRenderableText(normalizedText)
                     && findContainingLyricsRecyclerView(textView) == recycler) {
                 counts[0]++;
@@ -6478,7 +6513,7 @@ public final class LockscreenLyricsModule extends XposedModule {
                 return;
             }
             CharSequence text = textView.getText();
-            if (text == null || text.length() == 0 || text.length() > 240) {
+            if (text == null || text.length() == 0 || text.length() > lyricTextLengthLimit()) {
                 return;
             }
             String normalizedText = normalizedTextOf(textView);
@@ -7055,13 +7090,7 @@ public final class LockscreenLyricsModule extends XposedModule {
 
     private static boolean isOfficialTimedCurrentLyricExecutable(
             java.lang.reflect.Executable executable) {
-        if (executable == null || !"l".equals(executable.getName())) {
-            return false;
-        }
-        Class<?>[] parameterTypes = executable.getParameterTypes();
-        return parameterTypes.length == 2
-                && isBooleanParameter(parameterTypes[0])
-                && parameterTypes[1] == long.class;
+        return TimedLyricMethodPolicy.matches(executable);
     }
 
     private void tryInstallRecyclerAdapterNotifyHook(ClassLoader classLoader) {
@@ -7292,7 +7321,7 @@ public final class LockscreenLyricsModule extends XposedModule {
         ensureScreenTimeoutReceiver(textView.getContext());
 
         CharSequence currentText = textView.getText();
-        if (currentText == null || currentText.length() == 0 || currentText.length() > 240) {
+        if (currentText == null || currentText.length() == 0 || currentText.length() > lyricTextLengthLimit()) {
             return null;
         }
 
@@ -7587,6 +7616,8 @@ public final class LockscreenLyricsModule extends XposedModule {
         WordLine officialLine = model.lineAtOfficialDisplayIndex(officialIndex);
         int officialLineIndex = model.indexOfLine(officialLine);
         int activeLineIndex = model.indexOfLine(activeLine);
+        officialLineIndex = SentenceWindowContract.visualIndex(
+                hasSentenceWindow() ? position : -1L, activeLineIndex, officialLineIndex);
         return LockscreenIntegrationPolicy.chooseOfficialLyricVisualIndex(
                 officialLineIndex,
                 activeLineIndex,
@@ -7924,7 +7955,7 @@ public final class LockscreenLyricsModule extends XposedModule {
 
     private boolean hasUsableLyricText(TextView textView) {
         CharSequence text = textView == null ? null : textView.getText();
-        if (text == null || text.length() == 0 || text.length() > 240) {
+        if (text == null || text.length() == 0 || text.length() > lyricTextLengthLimit()) {
             return false;
         }
         return !TextUtils.isEmpty(normalizedTextOf(textView));
@@ -9121,7 +9152,7 @@ public final class LockscreenLyricsModule extends XposedModule {
                 continue;
             }
             CharSequence currentText = textView.getText();
-            if (currentText == null || currentText.length() == 0 || currentText.length() > 240) {
+            if (currentText == null || currentText.length() == 0 || currentText.length() > lyricTextLengthLimit()) {
                 continue;
             }
             String normalized = normalizedTextOf(textView);
@@ -9311,7 +9342,7 @@ public final class LockscreenLyricsModule extends XposedModule {
             CharSequence text = textView.getText();
             String normalized = text == null ? "" : normalizedTextOf(textView);
             if (text != null
-                    && text.length() <= 240
+                    && text.length() <= lyricTextLengthLimit()
                     && isInLyricsRecyclerView(textView)
                     && (normalized.equals(normalizedLine) || model.hasRenderableText(normalized))
                     && !containsTextView(candidates, textView)) {
@@ -10439,7 +10470,7 @@ public final class LockscreenLyricsModule extends XposedModule {
             return false;
         }
         String displayLyric = payload.lyric;
-        String rawLyric = payload.rawLyric;
+        String rawLyric = SentenceWindowContract.renderSource(payload);
         String translationLyric = payload.translationLyric;
         boolean displayTimed = LyricInfoContract.containsTimedLrc(displayLyric);
         boolean rawTimed = LyricInfoContract.containsTimedLrc(rawLyric);
@@ -10530,6 +10561,9 @@ public final class LockscreenLyricsModule extends XposedModule {
         }
 
         WordLyricModel model = assembled.model;
+        if (payload.snapshotPositionMillis >= 0L) {
+            for (WordLine line : model.lines) line.sentenceWindowExpanded = true;
+        }
         if (model.lines.isEmpty()) {
             clearWordLyricModelState(
                     BridgeDebugArea.RENDERER,
@@ -10938,6 +10972,10 @@ public final class LockscreenLyricsModule extends XposedModule {
     }
 
     private long estimatePlaybackPositionMillis() {
+        LyricInfoContract.Payload snapshot = currentLyricProviderPayload;
+        if (snapshot != null && snapshot.snapshotPositionMillis >= 0L) {
+            return snapshot.snapshotPositionMillis;
+        }
         long base = lastComputedPositionMs;
         long elapsed = lastComputedPositionElapsedMs;
         if (base >= 0 && (!lastPlaybackIsPlaying || elapsed < 0)) {
@@ -11925,7 +11963,9 @@ public final class LockscreenLyricsModule extends XposedModule {
         private static final float SETTLED_GLOW_RADIUS_FACTOR = 1.22f;
         private static final float SETTLED_GLOW_ALPHA_FACTOR = 0.88f;
         private static final float WRAPPED_LINE_BASE_GAP_DP = 1f;
-        private static final int VISIBLE_MAIN_DRAW_LINES = 2;
+        private static int visibleMainDrawLines(WordLine line) {
+            return line == null ? 2 : line.visibleWrappedLineLimit();
+        }
         private static final long FOCUSED_REVEAL_ANIMATION_MS = 260L;
         private static final long MAIN_LINE_WINDOW_ANIMATION_MS = 220L;
         private static final float MAIN_LINE_WINDOW_SLIDE_DP = 7f;
@@ -12718,7 +12758,7 @@ public final class LockscreenLyricsModule extends XposedModule {
                     : null;
             int visibleMainLineCount = LyricUiLayoutPolicy.visibleMainLineCount(
                     drawLines.size(),
-                    VISIBLE_MAIN_DRAW_LINES);
+                    visibleMainDrawLines(line));
 
             inactivePaint.getFontMetrics(mainFontMetrics);
             Paint.FontMetrics mainMetrics = mainFontMetrics;
@@ -12965,7 +13005,7 @@ public final class LockscreenLyricsModule extends XposedModule {
                     && line.timingMode == LyricTimingMode.LINE_TIMED
                     && !lineTimedProgressEnabled
                     && !aodLowFrameRateMode
-                    && totalLines > VISIBLE_MAIN_DRAW_LINES;
+                    && totalLines > visibleMainDrawLines(line);
         }
 
         private static float clampTopWithinSlot(
@@ -13219,7 +13259,7 @@ public final class LockscreenLyricsModule extends XposedModule {
             int fullMainLineCount = drawLines.size();
             int visibleMainLineCount = LyricUiLayoutPolicy.visibleMainLineCount(
                     fullMainLineCount,
-                    VISIBLE_MAIN_DRAW_LINES);
+                    visibleMainDrawLines(line));
 
             inactivePaint.getFontMetrics(mainFontMetrics);
             Paint.FontMetrics mainMetrics = mainFontMetrics;
@@ -13328,8 +13368,8 @@ public final class LockscreenLyricsModule extends XposedModule {
             int totalLines = drawLines.size();
             int count = LyricUiLayoutPolicy.visibleMainLineCount(
                     totalLines,
-                    VISIBLE_MAIN_DRAW_LINES);
-            if (totalLines <= VISIBLE_MAIN_DRAW_LINES) {
+                    visibleMainDrawLines(line));
+            if (totalLines <= visibleMainDrawLines(line)) {
                 resetMainLineWindow(line, 0, availableWidth);
                 return mainLineWindow.set(0, 0, count, 1f, 1f, false);
             }
@@ -13436,7 +13476,7 @@ public final class LockscreenLyricsModule extends XposedModule {
                         resolveLineDisplayEndMillis(model, line),
                         line.rendererLayoutWidths,
                         totalLines,
-                        VISIBLE_MAIN_DRAW_LINES);
+                        visibleMainDrawLines(line));
             }
             if (activeWord == null) {
                 return 0;
@@ -13447,7 +13487,7 @@ public final class LockscreenLyricsModule extends XposedModule {
                     return LockscreenIntegrationPolicy.clampSlidingWindowStart(
                             i,
                             totalLines,
-                            VISIBLE_MAIN_DRAW_LINES);
+                            visibleMainDrawLines(line));
                 }
             }
             return 0;

--- a/app/src/main/java/io/github/andrealtb/lockscreenlyrics/LyricInfoContract.java
+++ b/app/src/main/java/io/github/andrealtb/lockscreenlyrics/LyricInfoContract.java
@@ -70,7 +70,8 @@ public final class LyricInfoContract {
                     object.optString(JSON_PROVIDER, ""),
                     object.optString(JSON_TRACK_KEY, ""),
                     object.optLong(JSON_SESSION_GENERATION, 0L),
-                    object.optString(JSON_SOURCE, "")
+                    object.optString(JSON_SOURCE, ""),
+                    SentenceWindowContract.position(object, resolvedLyric)
             );
         } catch (Throwable ignored) {
             return null;
@@ -85,6 +86,9 @@ public final class LyricInfoContract {
             JSONObject object = new JSONObject(value);
             String lyric = object.optString(JSON_LYRIC, "");
             Payload originalPayload = parse(value);
+            if (originalPayload != null && originalPayload.snapshotPositionMillis >= 0L) {
+                return new NormalizedPayload(value, originalPayload, false);
+            }
             if (!containsTimedLrc(lyric)) {
                 return new NormalizedPayload(value, originalPayload, false);
             }
@@ -143,6 +147,7 @@ public final class LyricInfoContract {
         public final String trackKey;
         public final long sessionGeneration;
         public final String source;
+        public final long snapshotPositionMillis;
 
         Payload(
                 String songName,
@@ -156,6 +161,14 @@ public final class LyricInfoContract {
                 String trackKey,
                 long sessionGeneration,
                 String source) {
+            this(songName, artist, album, songId, lyric, rawLyric, translationLyric,
+                    provider, trackKey, sessionGeneration, source, -1L);
+        }
+
+        Payload(String songName, String artist, String album, String songId, String lyric,
+                String rawLyric, String translationLyric, String provider, String trackKey,
+                long sessionGeneration, String source, long snapshotPositionMillis) {
+            this.snapshotPositionMillis = snapshotPositionMillis;
             this.songName = songName;
             this.artist = artist;
             this.album = album;

--- a/app/src/main/java/io/github/andrealtb/lockscreenlyrics/PlayerSystemUiPolicy.java
+++ b/app/src/main/java/io/github/andrealtb/lockscreenlyrics/PlayerSystemUiPolicy.java
@@ -29,6 +29,9 @@ final class PlayerSystemUiPolicy {
     static final String QZ_MUSIC = "love.qz.music";
     static final String PRISM_MUSIC = "com.lg.sllocalmusic";
     static final String MD3_MUSIC = "com.md3music.md3music";
+    // Readify 3.1.0: on-device lyricInfo publication succeeds, but OPlus admission
+    // requires the same package-only compatibility as other native publishers.
+    static final String READIFY = "com.readin.app";
 
     private static final String[] OPLUS_HISTORY_PACKAGES = {
             QQ_MUSIC,
@@ -51,7 +54,8 @@ final class PlayerSystemUiPolicy {
             FLAMINGO,
             QZ_MUSIC,
             PRISM_MUSIC,
-            MD3_MUSIC
+            MD3_MUSIC,
+            READIFY
     };
 
     private PlayerSystemUiPolicy() {

--- a/app/src/main/java/io/github/andrealtb/lockscreenlyrics/SentenceWindowContract.java
+++ b/app/src/main/java/io/github/andrealtb/lockscreenlyrics/SentenceWindowContract.java
@@ -1,0 +1,29 @@
+package io.github.andrealtb.lockscreenlyrics;
+
+import java.util.Locale;
+import org.json.JSONObject;
+
+/** Opt-in event-driven rows. Slot tags encode order; they are not audio timestamps. */
+final class SentenceWindowContract {
+    private SentenceWindowContract() {}
+
+    static String renderSource(LyricInfoContract.Payload payload) {
+        return payload.snapshotPositionMillis >= 0L ? payload.lyric : payload.rawLyric;
+    }
+
+    static int visualIndex(long snapshotPosition, int activeIndex, int officialIndex) {
+        return snapshotPosition >= 0L ? activeIndex : officialIndex;
+    }
+
+    static long position(JSONObject object, String lyric) {
+        if (!"sentence-window-v1".equals(object.optString("displayMode"))) return -1L;
+        int current = object.optInt("currentLine", -1);
+        String[] lines = lyric.split("\n");
+        if (lines.length < 1 || lines.length > 5 || current < 0 || current >= lines.length) return -1L;
+        for (int i = 0; i < lines.length; i++) {
+            String tag = String.format(Locale.ROOT, "[00:%02d.000]", i);
+            if (!lines[i].startsWith(tag) || lines[i].substring(tag.length()).trim().isEmpty()) return -1L;
+        }
+        return current * 1000L;
+    }
+}

--- a/app/src/main/java/io/github/andrealtb/lockscreenlyrics/TimedLyricMethodPolicy.java
+++ b/app/src/main/java/io/github/andrealtb/lockscreenlyrics/TimedLyricMethodPolicy.java
@@ -1,0 +1,31 @@
+package io.github.andrealtb.lockscreenlyrics;
+
+import java.lang.reflect.Executable;
+import java.lang.reflect.Method;
+import java.lang.reflect.Modifier;
+
+/** Firmware-independent fallback, accepted only when the signature is unique. */
+final class TimedLyricMethodPolicy {
+    private TimedLyricMethodPolicy() {}
+
+    static boolean matches(Executable executable) {
+        if (!(executable instanceof Method) || !shape((Method) executable)) return false;
+        if ("l".equals(executable.getName())) return true;
+        int candidates = 0;
+        for (Method method : executable.getDeclaringClass().getDeclaredMethods()) {
+            if (shape(method)) candidates++;
+        }
+        return candidates == 1;
+    }
+
+    private static boolean shape(Method method) {
+        Class<?>[] types = method.getParameterTypes();
+        return !Modifier.isStatic(method.getModifiers()) && method.getReturnType() == void.class
+                && types.length == 2 && (types[0] == boolean.class || types[0] == Boolean.class)
+                && types[1] == long.class;
+    }
+
+    static long position(long snapshotPosition, long nativePosition) {
+        return snapshotPosition >= 0L ? snapshotPosition : nativePosition;
+    }
+}

--- a/app/src/main/java/io/github/andrealtb/lockscreenlyrics/render/WordLine.java
+++ b/app/src/main/java/io/github/andrealtb/lockscreenlyrics/render/WordLine.java
@@ -14,6 +14,12 @@ import java.util.Arrays;
  * {@code LockscreenLyricsModule} in step 3.1.
  */
 public final class WordLine {
+    public boolean sentenceWindowExpanded;
+
+    public int visibleWrappedLineLimit() {
+        return sentenceWindowExpanded ? 256 : 2;
+    }
+
 
     public final long timeMillis;
     public final long endTimeMillis;

--- a/app/src/test/java/io/github/andrealtb/lockscreenlyrics/NativeLyricModelAssemblerTest.java
+++ b/app/src/test/java/io/github/andrealtb/lockscreenlyrics/NativeLyricModelAssemblerTest.java
@@ -37,6 +37,26 @@ public final class NativeLyricModelAssemblerTest {
     }
 
     @Test
+    public void snapshotWithoutRawLyricBuildsModelAndSelectsExactCurrentRow() throws Exception {
+        String lrc = "[00:00.000]previous\n[00:01.000]current\n[00:02.000]next\n";
+        for (int index = 0; index < 3; index++) {
+            org.json.JSONObject json = new org.json.JSONObject().put("lyric", lrc)
+                    .put("displayMode", "sentence-window-v1").put("currentLine", index);
+            LyricInfoContract.Payload payload = LyricInfoContract.parse(json.toString());
+            String source = SentenceWindowContract.renderSource(payload);
+            assertTrue(LyricInfoContract.containsTimedLrc(source));
+            WordLyricModel model = assembler().assemble(source, true, payload.lyric, true, "").model;
+            assertEquals(3, model.lines.size());
+            assertEquals(index, model.indexOfLine(model.findActiveLine(payload.snapshotPositionMillis)));
+            assertEquals(index, SentenceWindowContract.visualIndex(payload.snapshotPositionMillis, index, 2));
+        }
+        LyricInfoContract.Payload music = LyricInfoContract.parse(
+                new org.json.JSONObject().put("lyric", lrc).toString());
+        assertEquals("", SentenceWindowContract.renderSource(music));
+        assertEquals(2, SentenceWindowContract.visualIndex(-1L, 0, 2));
+    }
+
+    @Test
     public void assemblesWordTimedPayloadWithAliasesAndSupplementalTranslations() {
         String raw = "[00:01.000] <00:01.000>Hel <00:01.300>lo<00:01.800>\n"
                 + "[00:01.000]你好\n"

--- a/app/src/test/java/io/github/andrealtb/lockscreenlyrics/PlayerSystemUiPolicyTest.java
+++ b/app/src/test/java/io/github/andrealtb/lockscreenlyrics/PlayerSystemUiPolicyTest.java
@@ -16,17 +16,26 @@ public final class PlayerSystemUiPolicyTest {
         Set<String> packages = new HashSet<>(
                 Arrays.asList(PlayerSystemUiPolicy.oplusHistoryPackages()));
 
-        assertEquals(21, packages.size());
+        assertEquals(22, packages.size());
         assertTrue(packages.contains(PlayerSystemUiPolicy.MD3_MUSIC));
         for (String packageName : new String[]{
                 PlayerSystemUiPolicy.HALCYON,
                 PlayerSystemUiPolicy.FLAMINGO,
                 PlayerSystemUiPolicy.QZ_MUSIC,
-                PlayerSystemUiPolicy.PRISM_MUSIC
+                PlayerSystemUiPolicy.PRISM_MUSIC,
+                PlayerSystemUiPolicy.READIFY
         }) {
             assertTrue(packages.contains(packageName));
             assertFalse(PlayerSystemUiPolicy
                     .supportsFavoriteTranslationOverride(packageName));
         }
+    }
+
+    @Test
+    public void readifyAdmissionDoesNotIncludeProviderOrOtherPackages() {
+        assertTrue(PlayerSystemUiPolicy.isHistoryPackage("com.readin.app"));
+        assertFalse(PlayerSystemUiPolicy.isHistoryPackage("de.sqlsec.readifylyrics"));
+        assertFalse(PlayerSystemUiPolicy.isHistoryPackage("com.readin.app.preview"));
+        assertFalse(PlayerSystemUiPolicy.supportsFavoriteTranslationOverride("com.readin.app"));
     }
 }

--- a/app/src/test/java/io/github/andrealtb/lockscreenlyrics/SentenceWindowContractTest.java
+++ b/app/src/test/java/io/github/andrealtb/lockscreenlyrics/SentenceWindowContractTest.java
@@ -1,0 +1,28 @@
+package io.github.andrealtb.lockscreenlyrics;
+
+import static org.junit.Assert.assertEquals;
+import org.json.JSONObject;
+import org.junit.Test;
+
+public final class SentenceWindowContractTest {
+    @Test public void snapshotIndexSurvivesParsingAndNormalization() throws Exception {
+        JSONObject json = payload();
+        assertEquals(1000L, LyricInfoContract.parse(json.toString()).snapshotPositionMillis);
+        assertEquals(1000L, LyricInfoContract.normalizeOfficialLyricInfo(json.toString()).payload.snapshotPositionMillis);
+    }
+
+    @Test public void musicAndInvalidWindowsKeepPlaybackClock() throws Exception {
+        JSONObject json = payload();
+        json.remove("displayMode");
+        assertEquals(-1L, LyricInfoContract.parse(json.toString()).snapshotPositionMillis);
+        json = payload().put("currentLine", 3);
+        assertEquals(-1L, LyricInfoContract.parse(json.toString()).snapshotPositionMillis);
+        json = payload().put("lyric", "[00:00.000]a\n[00:03.000]b\n");
+        assertEquals(-1L, LyricInfoContract.parse(json.toString()).snapshotPositionMillis);
+    }
+
+    private JSONObject payload() throws Exception {
+        return new JSONObject().put("displayMode", "sentence-window-v1").put("currentLine", 1)
+                .put("lyric", "[00:00.000]previous\n[00:01.000]current\n[00:02.000]next\n");
+    }
+}

--- a/app/src/test/java/io/github/andrealtb/lockscreenlyrics/TimedLyricMethodPolicyTest.java
+++ b/app/src/test/java/io/github/andrealtb/lockscreenlyrics/TimedLyricMethodPolicyTest.java
@@ -1,0 +1,28 @@
+package io.github.andrealtb.lockscreenlyrics;
+
+import static org.junit.Assert.*;
+import org.junit.Test;
+
+public final class TimedLyricMethodPolicyTest {
+    static class Renamed { void x(boolean animate, long position) {} }
+    static class Ambiguous {
+        void x(boolean animate, long position) {}
+        void y(boolean animate, long position) {}
+    }
+    static class Legacy {
+        void l(boolean animate, long position) {}
+        void y(boolean animate, long position) {}
+    }
+    @Test public void uniquelyRenamedMethodMatchesButAmbiguityDoesNot() throws Exception {
+        assertTrue(TimedLyricMethodPolicy.matches(Renamed.class.getDeclaredMethod("x", boolean.class, long.class)));
+        assertFalse(TimedLyricMethodPolicy.matches(Ambiguous.class.getDeclaredMethod("x", boolean.class, long.class)));
+        assertTrue(TimedLyricMethodPolicy.matches(Legacy.class.getDeclaredMethod("l", boolean.class, long.class)));
+    }
+    @Test public void holdsUntilNextEventRegardlessOfNativeElapsedTime() {
+        for (long elapsed : new long[] {0, 1000, 3000, 10000, 60000}) {
+            assertEquals(2000L, TimedLyricMethodPolicy.position(2000L, elapsed));
+            assertEquals(elapsed, TimedLyricMethodPolicy.position(-1L, elapsed));
+        }
+        assertEquals(1000L, TimedLyricMethodPolicy.position(1000L, 60000));
+    }
+}

--- a/app/src/test/java/io/github/andrealtb/lockscreenlyrics/UniversalPlayerBridgeContractTest.java
+++ b/app/src/test/java/io/github/andrealtb/lockscreenlyrics/UniversalPlayerBridgeContractTest.java
@@ -51,7 +51,7 @@ public final class UniversalPlayerBridgeContractTest {
 
     @Test
     public void runtimeExtrasJoinHistoryWithoutMutatingStaticWhitelist() {
-        assertEquals(21, PlayerSystemUiPolicy.oplusHistoryPackages().length);
+        assertEquals(22, PlayerSystemUiPolicy.oplusHistoryPackages().length);
         assertFalse(PlayerSystemUiPolicy.isHistoryPackage("remix.myplayer"));
         UniversalPlayerBridgeContract.applyRuntimeBindings(
                 true,
@@ -60,7 +60,6 @@ public final class UniversalPlayerBridgeContractTest {
         assertTrue(PlayerSystemUiPolicy.isHistoryPackage("remix.myplayer"));
         assertTrue(PlayerSystemUiPolicy.isHistoryPackage(PlayerSystemUiPolicy.SALT));
         assertFalse(PlayerSystemUiPolicy.isHistoryPackage("com.tencent.qqmusicpad"));
-        assertEquals(21, PlayerSystemUiPolicy.oplusHistoryPackages().length);
+        assertEquals(22, PlayerSystemUiPolicy.oplusHistoryPackages().length);
     }
 }
-

--- a/app/src/test/java/io/github/andrealtb/lockscreenlyrics/render/LyricDrawLayoutEngineTest.java
+++ b/app/src/test/java/io/github/andrealtb/lockscreenlyrics/render/LyricDrawLayoutEngineTest.java
@@ -11,6 +11,26 @@ import java.util.List;
 
 public final class LyricDrawLayoutEngineTest {
     @Test
+    public void expandedSentenceKeepsAllWrappedCharactersBeyondTwoLines() {
+        String text = "这是一段需要超过两行才能显示完整的朗读文字，末尾几个字也必须保留。";
+        WordLine line = line(text);
+        LyricDrawLayoutEngine engine = new LyricDrawLayoutEngine(
+                (value, start, end) -> end - start);
+        engine.build(line, text, 8f, false, false, 100, null);
+        assertTrue(engine.lines().size() > 2);
+        assertEquals(2, line.visibleWrappedLineLimit());
+        line.sentenceWindowExpanded = true;
+        int visible = Math.min(engine.lines().size(), line.visibleWrappedLineLimit());
+        StringBuilder displayed = new StringBuilder();
+        for (int i = 0; i < visible; i++) {
+            LyricDrawLine row = engine.lines().get(i);
+            displayed.append(text, row.start, row.end);
+        }
+        assertEquals(text, displayed.toString());
+        assertEquals(2, line("ordinary music").visibleWrappedLineLimit());
+    }
+
+    @Test
     public void wrapsAtWhitespaceAndTrimsSegments() {
         LyricDrawLayoutEngine engine = new LyricDrawLayoutEngine(
                 (text, start, end) -> end - start);

--- a/docs/SENTENCE_WINDOWS.md
+++ b/docs/SENTENCE_WINDOWS.md
@@ -1,0 +1,60 @@
+# Event-driven sentence windows
+
+Readify AI 3.1.0 (`com.readin.app`) can publish a bounded view of the current TTS
+utterance and its already-prefetched neighbors through its own `MediaSession`.
+The Provider owns text extraction, stable identity, and lifecycle. Bridge owns
+SystemUI rendering. The Bridge Xposed scope stays `system` / `com.android.systemui`.
+
+## Payload extension (proposed)
+
+Standard `lyricInfo` identity fields are unchanged. Opt in with:
+
+```json
+{
+  "songName": "Example book",
+  "artist": "",
+  "trackKey": "book-id|example book||0",
+  "provider": "com.readin.app",
+  "displayMode": "sentence-window-v1",
+  "currentLine": 1,
+  "lyric": "[00:00.000]Previous sentence\n[00:01.000]Current sentence\n[00:02.000]Following sentence\n"
+}
+```
+
+`currentLine` is zero-based. Accept one to five nonempty rows with sequential
+0/1/2/3/4-second slot tags. These tags encode row order, **not audio durations**.
+The index remains fixed until the next Provider event; no elapsed-time advance.
+Invalid or absent extensions retain normal timed-lyric behavior.
+
+For valid windows, use `lyric` as the render-model source even without `rawLyric`,
+skip opening cleanup that could change indices, and align both native lyric
+updates and custom focus to the snapshot position. Native boolean/animation
+arguments and the actual player PlaybackState remain unchanged. Discover a
+renamed `void(boolean,long)` lyric method only when that shape is unique;
+ambiguous fallback candidates are not hooked. The legacy name remains supported.
+
+Window rows expand to their wrapped text height instead of the music two-line
+sliding window. The text-view recognition limit covers the Provider's bounded
+1600-code-point text. Extremely tall paragraphs still exceed a physical screen.
+Ordinary music retains its current two-line and playback-clock policies.
+
+## Validation
+
+The tester reported correct current-line hold, sentence changes, and long-text
+rendering with Readify AI 3.1.0 online Chunk AI speech on OnePlus 13 (PJZ110),
+Android 16, LSPosed 2.2.0 / API 102. Device tests used local test packages based on
+Bridge v4.2.0; the final upstream branch has not been installed on that device.
+No screenshot/recording of the final working state is attached yet.
+
+Redacted diagnostics (no book titles or body text):
+
+```text
+published/readback ok; mode=sentence-window rows=5 current=2
+SENTENCE_WINDOW_ACCEPTED: Snapshot accepted; current=2
+```
+
+Regression coverage includes protocol parsing, model construction without
+rawLyric, every active row, rejecting ambiguous reflected methods, holding the
+index while native time advances, and preserving all wrapped Chinese text.
+This proposal requires the companion Readify Provider PR and maintainer review
+of the new wire extension before release.


### PR DESCRIPTION
Readify TTS can publish several neighboring sentences, but their audio durations are not known in advance. Treating those rows as a song timeline advances highlighting before speech finishes; the ordinary two-line window also hides the end of long utterances.

This proposes an opt-in `sentence-window-v1` extension with a zero-based current-line index. Bridge builds a render model from the window, holds native lyric updates and visual focus on the indicated row until the next event, and expands wrapped sentence rows. It also adds `com.readin.app` to the OPlus compatibility policy and handles uniquely identifiable renamed lyric-update methods. Normal music keeps its playback clock and two-line behavior. Bridge's official system-only LSPosed scope and release version/signing configuration are unchanged.

Protocol, process boundaries, redacted diagnostics and limitations: `docs/SENTENCE_WINDOWS.md`. Companion Provider PR: https://github.com/Andrea-lyz/ColorOS-Live-Lyrics-Providers/pull/1

Validation on the current upstream main checkout:
- `:app:testDebugUnitTest :app:lintDebug :app:assembleDebug` passed (521 tests: 515 passed, 6 fixture-dependent skips; no failures/errors).
- New regressions cover parser/model integration, every current index, ambiguous reflection rejection, clock hold and complete Chinese wrapping.
- The tester confirmed multi-line display, current-sentence hold and long-text display on OnePlus 13 / Android 16 / Readify AI 3.1.0 online Chunk AI speech with the local test builds. This final upstream checkout has not been device-tested separately.

Draft for review of the wire extension and companion Provider integration. A shareable screenshot/recording of the final working state is still pending; no private books, raw device logs, APKs or signing material are included.
